### PR TITLE
increase required exec env for slingshot.model

### DIFF
--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.slingshot.model/META-INF/MANIFEST.MF
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.slingshot.model/META-INF/MANIFEST.MF
@@ -7,7 +7,7 @@ Bundle-ClassPath: .
 Bundle-Vendor: %providerName
 Bundle-Localization: plugin
 Automatic-Module-Name: org.palladiosimulator.experimentautomation.application.tooladapter.slingshot.model
-Bundle-RequiredExecutionEnvironment: JavaSE-11
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Export-Package: org.palladiosimulator.experimentautomation.application.tooladapter.slingshot.model,
  org.palladiosimulator.experimentautomation.application.tooladapter.slingshot.model.impl,
  org.palladiosimulator.experimentautomation.application.tooladapter.slingshot.model.util


### PR DESCRIPTION
Bundle-RequiredExecutionEnvironment was at JavaSE-11, i increased it to JavaSE-17