### PR TITLE
Bump Tycho version from 2.7.5 to 4.0.13

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.5</version>
+		<version>4.0.13</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,22 @@
 	
 	<properties>
 		<targetPlatform.relativePath>releng/org.palladiosimulator.experimentautomation.targetplatform/tp.target</targetPlatform.relativePath>
+		<tycho.version>4.0.13</tycho.version>
 	</properties>
+	
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>target-platform-configuration</artifactId>
+					<configuration>
+						<executionEnvironment>JavaSE-17</executionEnvironment>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 	
 	<modules>
 		<module>bundles</module>


### PR DESCRIPTION
Align with Palladio-Build-MavenParent [#65](https://github.com/PalladioSimulator/Palladio-Build-MavenParent/pull/65) which upgrades the parent POM from 2.7.5 to 4.0.13.

- Update `.mvn/extensions.xml` to use `tycho-build:4.0.13`
- Override `<tycho.version>` to `4.0.13` in root pom.xml
- Set `<executionEnvironment>JavaSE-17</executionEnvironment>` in `target-platform-configuration` to prevent autodetection of JavaSE-21 on JDK 21