### PR TITLE
Add standalone product module for headless experiment execution

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -3,6 +3,6 @@
 	<extension>
 		<groupId>org.eclipse.tycho</groupId>
 		<artifactId>tycho-build</artifactId>
-		<version>2.7.5</version>
+		<version>4.0.13</version>
 	</extension>
 </extensions>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,22 @@
 	
 	<properties>
 		<targetPlatform.relativePath>releng/org.palladiosimulator.experimentautomation.targetplatform/tp.target</targetPlatform.relativePath>
+		<tycho.version>4.0.13</tycho.version>
 	</properties>
+	
+	<build>
+		<pluginManagement>
+			<plugins>
+				<plugin>
+					<groupId>org.eclipse.tycho</groupId>
+					<artifactId>target-platform-configuration</artifactId>
+					<configuration>
+						<executionEnvironment>JavaSE-17</executionEnvironment>
+					</configuration>
+				</plugin>
+			</plugins>
+		</pluginManagement>
+	</build>
 	
 	<modules>
 		<module>bundles</module>

--- a/releng/org.palladiosimulator.experimentautomation.product/AGENTS.md
+++ b/releng/org.palladiosimulator.experimentautomation.product/AGENTS.md
@@ -1,0 +1,78 @@
+# Agent context — Experiment Automation Product
+
+## Purpose
+
+`releng/org.palladiosimulator.experimentautomation.product/` builds a
+standalone Eclipse RCP product of the Palladio Experiment Automation,
+bundling the headless experiment application with all dependencies
+(PCM, SimuLizar, SimuCom, SSJ simulation engine, EDP2, etc.) into
+platform-specific archives with native launchers.
+
+Not part of the regular reactor (`releng/pom.xml`).  Built manually via
+`-f ...product/pom.xml`.
+
+## Key files
+
+- `product.product` – Eclipse product definition (`useFeatures="true"`,
+  `includeLaunchers="true"`, application
+  `org.palladiosimulator.experimentautomation.application`)
+- `pom.xml` – `eclipse-repository` packaging, delegates to
+  `tycho-p2-director-plugin` for materialize + archive
+
+## Build order
+
+1. `mvn clean package -DskipTests` (root) → produces updatesite at
+   `releng/...updatesite/target/repository`
+2. `mvn clean verify -f releng/...product/pom.xml` → materialises product
+
+The product POM references these p2 repositories:
+
+| Repo | ID | Purpose |
+|---|---|---|
+| Local updatesite | `local-updatesite` | `file://` to the built EA updatesite |
+| Eclipse 2023-03 | `eclipse-2023-03` | Equinox executable feature (native launchers) |
+| AbstractSimEngine (nightly) | `abstractsimengine` | SSJ + abstractsimengine features/plugins |
+| Third-party wrapper (nightly) | `thirdparty-wrapper` | DESMO-J, Apache Commons Math, etc. |
+| Third-party library (nightly) | `thirdparty-library` | `ca.umontreal.iro.simul.ssj` (SSJ math lib) |
+
+## Product contents
+
+Included features (in order):
+
+- `org.palladiosimulator.pcm.feature` – PCM core (models, resources → pathmap)
+- `org.palladiosimulator.thirdpartywrapper.feature` – DESMO-J, JFreeChart, etc.
+- `ca.umontreal.iro.ssj.feature` – SSJ stochastic simulation library
+- `de.uka.ipd.sdq.simulation.abstractsimengine.feature` – abstract simulation API
+- `org.palladiosimulator.simulation.abstractsimengine.ssj.feature` – SSJ engine impl
+- `org.palladiosimulator.experimentautomation.application.feature` – main app
+- `...application.tooladapter.simulizar.feature` – SimuLizar adapter
+- `...application.tooladapter.simucom.feature` – SimuCom adapter
+
+All transitive dependencies (EMF, Equinox, workflow engine) are resolved
+from the target platform.
+
+## Status (2026-06-25)
+
+- **Build**: verified – all 5 platform archives produced (~175 MB each)
+- **SSJ engine**: included and resolved (no more NPE in engine init)
+- **Headless run**: verified via macOS aarch64 product – exit code 0
+- **Example**: `SimpleVariation.experiments` works (from espresso examples)
+
+## Known issues
+
+- **PCM pathmap** (`pathmap://PCM_MODELS/`) may not resolve at runtime;
+  the product boots and runs but model loading can fail.  Same issue as
+  in PCM.app headless runs.
+- **Henshin interpreter**: warning about missing
+  `org.eclipse.emf.henshin.interpreter` (non-fatal, from SimuLizar
+  reconfiguration).
+- **log4j warnings**: missing appenders – harmless, does not affect execution.
+- **Product branding**: "Product could not be found" message when using
+  `-application` directly – harmless.
+
+## Related
+
+- `releng/org.palladiosimulator.experimentautomation.updatesite/` –
+  produces the p2 repository that this product consumes
+- `releng/org.palladiosimulator.experimentautomation.targetplatform/` –
+  Eclipse target definition resolving upstream Palladio repos

--- a/releng/org.palladiosimulator.experimentautomation.product/README.md
+++ b/releng/org.palladiosimulator.experimentautomation.product/README.md
@@ -1,0 +1,101 @@
+# Palladio Experiment Automation — Standalone Product
+
+This module builds a standalone Eclipse RCP product of the Palladio Experiment
+Automation.  The product bundles the experiment application plus all transitive
+dependencies (PCM, SimuLizar, SimuCom, SSJ simulation engine, etc.) into a
+self-contained directory with native launchers for all supported platforms.
+
+## Requirements
+
+- JDK 17+ (tested with JDK 21)
+- Maven 3.8+
+- Network access to the Palladio nightly p2 repositories (see `pom.xml`)
+
+## Build
+
+### 1. Build the main project (bundles, features, updatesite)
+
+The product depends on the local updatesite.  Build it first:
+
+```bash
+mvn clean package -DskipTests
+```
+
+### 2. Build the product
+
+```bash
+mvn clean verify -f releng/org.palladiosimulator.experimentautomation.product/pom.xml
+```
+
+The product is materialised and archived for every platform in:
+
+```
+releng/org.palladiosimulator.experimentautomation.product/target/products/
+```
+
+Output per platform (~175 MB each):
+
+| Platform | Archive |
+|---|---|
+| macOS x86\_64 | `ExperimentAutomation-macosx.cocoa.x86_64.tar.gz` / `.app` |
+| macOS aarch64 | `ExperimentAutomation-macosx.cocoa.aarch64.tar.gz` / `.app` |
+| Linux x86\_64 | `ExperimentAutomation-linux.gtk.x86_64.tar.gz` |
+| Linux aarch64 | `ExperimentAutomation-linux.gtk.aarch64.tar.gz` |
+| Windows x86\_64 | `ExperimentAutomation-win32.win32.x86_64.zip` |
+
+The product is **not** part of the regular reactor build
+(`releng/pom.xml`).  It must be built manually as shown above.
+
+## Run
+
+### Via native launcher (macOS example)
+
+```bash
+./target/products/ExperimentAutomation/macosx/cocoa/aarch64/experiment-automation.app/Contents/MacOS/eclipse \
+  -application org.palladiosimulator.experimentautomation.application \
+  -data /tmp/ea-workspace \
+  /path/to/your/experiment.experiments
+```
+
+Use a fresh (or empty) `-data` directory each time to avoid workspace lock
+conflicts.
+
+### Via `java -jar`
+
+```bash
+java -jar target/products/ExperimentAutomation/macosx/cocoa/aarch64/experiment-automation.app/Contents/Eclipse/plugins/org.eclipse.equinox.launcher_*.jar \
+  -application org.palladiosimulator.experimentautomation.application \
+  -data /tmp/ea-workspace \
+  /path/to/your/experiment.experiments
+```
+
+### Example
+
+The espresso example ships experiment models in the
+`org.palladiosimulator.experimentautomation.examples.espresso` bundle:
+
+```bash
+/path/to/eclipse \
+  -application org.palladiosimulator.experimentautomation.application \
+  -data /tmp/ea-workspace \
+  /path/to/repo/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/Experiments/SimpleVariation.experiments
+```
+
+### Arguments
+
+| Argument | Description |
+|---|---|
+| `-data <dir>` | Eclipse workspace directory (required; arbitrary temp dir is fine) |
+| `<file.experiments>` | Path to the experiment repository model (`.experiments` extension) |
+
+### Known Issues
+
+- **PCM pathmap resolution**: `pathmap://PCM_MODELS/` URIs may fail if the
+  PCM model bundle is not fully initialised.  This is a pre-existing issue
+  that also affects PCM.app headless runs.
+- **Henshin interpreter**: warning about missing
+  `org.eclipse.emf.henshin.interpreter` (non-fatal, from SimuLizar
+  reconfiguration).
+- **Logging**: log4j warnings about missing appenders are harmless.
+- **Product branding**: the message "Product could not be found" on startup
+  is harmless when using `-application` directly.

--- a/releng/org.palladiosimulator.experimentautomation.product/pom.xml
+++ b/releng/org.palladiosimulator.experimentautomation.product/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.palladiosimulator.experimentautomation</groupId>
+		<artifactId>parent</artifactId>
+		<version>6.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>org.palladiosimulator.experimentautomation.product</artifactId>
+	<packaging>eclipse-repository</packaging>
+
+	<repositories>
+		<repository>
+			<id>local-updatesite</id>
+			<layout>p2</layout>
+			<url>file://${project.basedir}/../org.palladiosimulator.experimentautomation.updatesite/target/repository</url>
+		</repository>
+		<repository>
+			<id>eclipse-2023-03</id>
+			<layout>p2</layout>
+			<url>https://download.eclipse.org/releases/2023-03/</url>
+		</repository>
+		<repository>
+			<id>abstractsimengine</id>
+			<layout>p2</layout>
+			<url>https://updatesite.palladio-simulator.com/palladio-simulation-abstractsimengine/nightly/</url>
+		</repository>
+		<repository>
+			<id>thirdparty-wrapper</id>
+			<layout>p2</layout>
+			<url>https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/nightly/</url>
+		</repository>
+		<repository>
+			<id>thirdparty-library</id>
+			<layout>p2</layout>
+			<url>https://updatesite.palladio-simulator.com/palladio-thirdparty-library/nightly/</url>
+		</repository>
+	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-director-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<executions>
+					<execution>
+						<id>materialize-products</id>
+						<goals>
+							<goal>materialize-products</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>archive-products</id>
+						<goals>
+							<goal>archive-products</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<products>
+						<product>
+							<id>ExperimentAutomation</id>
+							<rootFolder>experiment-automation</rootFolder>
+						</product>
+					</products>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/releng/org.palladiosimulator.experimentautomation.product/product.product
+++ b/releng/org.palladiosimulator.experimentautomation.product/product.product
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+<product name="Palladio Experiment Automation" uid="ExperimentAutomation"
+         id="org.palladiosimulator.experimentautomation.product"
+         application="org.palladiosimulator.experimentautomation.application"
+         version="6.0.0.qualifier" useFeatures="true" includeLaunchers="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts</vmArgsMac>
+   </launcherArgs>
+
+   <windowImages/>
+
+   <features>
+      <feature id="org.palladiosimulator.pcm.feature"/>
+      <feature id="org.palladiosimulator.thirdpartywrapper.feature"/>
+      <feature id="ca.umontreal.iro.ssj.feature"/>
+      <feature id="de.uka.ipd.sdq.simulation.abstractsimengine.feature"/>
+      <feature id="org.palladiosimulator.simulation.abstractsimengine.ssj.feature"/>
+      <feature id="org.palladiosimulator.experimentautomation.application.feature"/>
+      <feature id="org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.feature"/>
+      <feature id="org.palladiosimulator.experimentautomation.application.tooladapter.simucom.feature"/>
+   </features>
+
+   <configurations>
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2"/>
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0"/>
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2"/>
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2"/>
+      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1"/>
+      <property name="osgi.instance.area.default" value="@user.home/workspace"/>
+   </configurations>
+
+</product>


### PR DESCRIPTION
Closes #37

## Summary

New `releng/org.palladiosimulator.experimentautomation.product/` module that builds a standalone Eclipse RCP product of the Experiment Automation.

## What it includes

- PCM core feature (models, resources → `pathmap://PCM_MODELS/` registration)
- Third-party wrapper (DESMO-J, Apache Commons Math, etc.)
- SSJ simulation library + SSJ engine adapter
- Abstract simulation engine API
- Experiment Automation application + tool adapters (SimuLizar, SimuCom)

## Build

```bash
# 1. Build the main project (updatesite)
mvn clean package -DskipTests

# 2. Build the product
mvn clean verify -f releng/org.palladiosimulator.experimentautomation.product/pom.xml
```

Output: 5 platform archives (~175 MB each) in `target/products/`.

## Verified

- Full build on macOS aarch64
- Headless experiment run with `SimpleVariation.experiments` → exit code 0
- SSJ engine resolved and bundled (no more NPE in engine initialisation)