### PR TITLE
Add standalone product module for headless experiment execution

### DIFF
--- a/.project
+++ b/.project
@@ -5,7 +5,24 @@
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121381</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/.settings/org.eclipse.m2e.core.prefs
+++ b/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/README.md
+++ b/README.md
@@ -1,34 +1,53 @@
 # Palladio Experiment Automation
+
 The Palladio Experiment Automation enables automatic execution of Palladio simulation runs. Allows to specify experiment runs for arbitrary solvers within a model; also supports experiment variations, e.g., for sensitivity analyses.
 
+## Standalone Product
+
+A standalone Eclipse RCP product can be built that runs experiments headlessly without the Palladio Bench:
+
+- [Product module](releng/org.palladiosimulator.experimentautomation.product/) – builds platform-specific archives (macOS, Linux, Windows)
+- [Docker module](releng/org.palladiosimulator.experimentautomation.product.docker/) – builds a runnable Linux Docker image
+
+Both include the SSJ simulation engine and support SimuLizar / SimuCom analyzers.
+
 ## Documentation
+
 So far, the Palladio Bench requires user interaction to configure and launch a simulation run, both of which is done using the the SimuBench launch configuration type. While being sufficient for single simulation runs, larger simulation studies with plenty of similar but distinct runs are tedious to perform this way and the desire for automation arises. The Palladio Experiment Automation project aims a filling this gap.
 
 ### Features
-* Simulates a specified PCM model with a given simulation configuration
-* Simulates an experiment series referring to a specified PCM model which is automatically modified over the course of the experiment series. E.g. the population of a closed workload might be systematically increased.
-* Comes with a configuration-metamodel whose instances describe which PCM model is to be used, what is the simulation configuration and how the PCM model is going to be modified over the course of the experiment series
-* Runs headless, i.e. without a graphical user interface (GUI) present. This way, experiments can be launched from command line, but also in a graphical environment.
+
+- Simulates a specified PCM model with a given simulation configuration
+- Simulates an experiment series referring to a specified PCM model which is automatically modified over the course of the experiment series. E.g. the population of a closed workload might be systematically increased.
+- Comes with a configuration-metamodel whose instances describe which PCM model is to be used, what is the simulation configuration and how the PCM model is going to be modified over the course of the experiment series
+- Runs headless, i.e. without a graphical user interface (GUI) present. This way, experiments can be launched from command line, but also in a graphical environment.
 
 ### Further information
+
 Development of the Palladio Experiment Automation started in the course of a master's thesis. Please refer to the corresponding [thesis](http://sdqweb.ipd.kit.edu/publications/pdfs/merkle2011a.pdf)(pp. 65 ff.) for more information.
 
 ### Technical documentation
+
 #### Technical overview
+
 Palladio Experiment Automation...
 
-* ...comprises a number of Eclipse plug-ins
-* ...is an Eclipse Application, meaning that it extends the org.eclipse.core.runtime.applications extension point
-* ...provides no graphical widgets or views, respectively - experiment series or single simulation runs are configured solely on the basis of a configuration model
+- ...comprises a number of Eclipse plug-ins
+- ...is an Eclipse Application, meaning that it extends the org.eclipse.core.runtime.applications extension point
+- ...provides no graphical widgets or views, respectively - experiment series or single simulation runs are configured solely on the basis of a configuration model
 
 #### Installation
+
 ##### Installation from Update Site
+
 There is no release version yet. Currently, use the [(nightly) update site](https://sdqweb.ipd.kit.edu/eclipse/experimentautomation/nightly/).
 
 ##### Installation from GitHub
+
 Use the GitHub repository to check out all plug-ins ("org.palladiosimulator.experimentautomation*").
 
 #### Creating and Editing Configuration Models
+
 1. Install Eclipse and Palladio with Experiment Automation feature enabled
 1. Create a project (or use an existing one) - the project type (General, Java, ...) does not matter
 1. Select File -> New... -> Other... -> Example EMF Model Creation Wizards -> Experiments Model
@@ -37,6 +56,7 @@ Use the GitHub repository to check out all plug-ins ("org.palladiosimulator.expe
 1. Start modelling as usual with generated EMF tree-editors. You can find a simple example in the project "org.palladiosimulator.experimentautomation.examples.espresso".
 
 #### Running Experiments
+
 1. Start the Palladio-Bench with Experiment Automation feature enabled
 1. Create a PCM model to be simulated
 1. Create a configuration model as described above - the configuration model indirectly references the afore-created PCM model

--- a/bundles/.project
+++ b/bundles/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>bundles</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121362</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/bundles/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.model.edit/.project
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.model.edit/.project
@@ -20,9 +20,26 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121370</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.model.edit/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.model.edit/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.model.edit/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.model.edit/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.model/.project
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.model/.project
@@ -20,9 +20,26 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121369</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.model/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.model/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.model/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.model/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom/.project
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom/.project
@@ -25,10 +25,27 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121367</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simucom/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.model.edit/.project
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.model.edit/.project
@@ -20,9 +20,26 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121374</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.model.edit/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.model.edit/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.model.edit/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.model.edit/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.model/.project
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.model/.project
@@ -20,9 +20,26 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121373</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.model/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.model/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.model/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.model/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar/.project
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar/.project
@@ -25,10 +25,27 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121371</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.palladiosimulator.experimentautomation.application.ui/.project
+++ b/bundles/org.palladiosimulator.experimentautomation.application.ui/.project
@@ -25,10 +25,27 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121375</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/org.palladiosimulator.experimentautomation.application.ui/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.ui/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.palladiosimulator.experimentautomation.application.ui/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application.ui/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.palladiosimulator.experimentautomation.application/.project
+++ b/bundles/org.palladiosimulator.experimentautomation.application/.project
@@ -25,10 +25,27 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121365</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/org.palladiosimulator.experimentautomation.application/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.palladiosimulator.experimentautomation.application/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.application/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.palladiosimulator.experimentautomation.application/plugin.xml
+++ b/bundles/org.palladiosimulator.experimentautomation.application/plugin.xml
@@ -15,5 +15,13 @@
          </run>
       </application>
    </extension>
-   
+   <extension
+         id="product"
+         point="org.eclipse.core.runtime.products">
+      <product
+            application="org.palladiosimulator.experimentautomation.application"
+            name="Palladio Experiment Automation">
+      </product>
+   </extension>
+    
 </plugin>

--- a/bundles/org.palladiosimulator.experimentautomation.application/src/org/palladiosimulator/experimentautomation/application/jobs/ComputeVariantsAndAddExperimentJob.java
+++ b/bundles/org.palladiosimulator.experimentautomation.application/src/org/palladiosimulator/experimentautomation/application/jobs/ComputeVariantsAndAddExperimentJob.java
@@ -133,17 +133,22 @@ public class ComputeVariantsAndAddExperimentJob extends SequentialBlackboardInte
 
                 @Override
                 public Void caseSetValueProvider(final SetValueProvider object) {
-                    final IValueProviderStrategy<Double> valueProvider = ValueProviderFactory
-                            .createDoubleValueProvider(object);
+                    final boolean allIntegers = isAllIntegers(object.getValues());
 
                     int iteration = 0;
                     while (iteration < variation.getMaxVariations()) {
-                        final Double factorLevel = valueProvider.valueAtPosition(iteration);
-                        if (factorLevel == -1.0) {
+                        final String token = getToken(object.getValues(), iteration);
+                        if (token == null) {
                             break;
                         }
 
-                        variationFactorTuples.add(new VariationFactorTuple<Double>(variation, factorLevel));
+                        if (allIntegers) {
+                            variationFactorTuples
+                                    .add(new VariationFactorTuple<Long>(variation, Long.parseLong(token)));
+                        } else {
+                            variationFactorTuples
+                                    .add(new VariationFactorTuple<Double>(variation, Double.parseDouble(token)));
+                        }
                         ComputeVariantsAndAddExperimentJob.this.computeVariantsAndAddJob(experiment,
                                 simulationConfiguration, copy, variationFactorTuples);
                         variationFactorTuples.remove(variationFactorTuples.size() - 1);
@@ -155,5 +160,34 @@ public class ComputeVariantsAndAddExperimentJob extends SequentialBlackboardInte
 
             }.doSwitch(variation.getValueProvider());
         }
+    }
+
+    private static boolean isAllIntegers(final String values) {
+        if (values == null || values.isEmpty()) {
+            return true;
+        }
+        for (final String token : values.split(",")) {
+            final String trimmed = token.trim();
+            if (trimmed.contains(".") || trimmed.contains("e") || trimmed.contains("E")) {
+                return false;
+            }
+            try {
+                Long.parseLong(trimmed);
+            } catch (final NumberFormatException e) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static String getToken(final String values, final int position) {
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+        final String[] tokens = values.split(",");
+        if (position >= tokens.length) {
+            return null;
+        }
+        return tokens[position].trim();
     }
 }

--- a/bundles/org.palladiosimulator.experimentautomation.application/src/org/palladiosimulator/experimentautomation/application/jobs/ComputeVariantsAndAddExperimentJob.java
+++ b/bundles/org.palladiosimulator.experimentautomation.application/src/org/palladiosimulator/experimentautomation/application/jobs/ComputeVariantsAndAddExperimentJob.java
@@ -8,6 +8,7 @@ import org.palladiosimulator.experimentautomation.application.VariationFactorTup
 import org.palladiosimulator.experimentautomation.application.variation.valueprovider.IValueProviderStrategy;
 import org.palladiosimulator.experimentautomation.application.variation.valueprovider.ValueProviderFactory;
 import org.palladiosimulator.experimentautomation.experiments.Experiment;
+import org.palladiosimulator.experimentautomation.experiments.SetValueProvider;
 import org.palladiosimulator.experimentautomation.experiments.Variation;
 import org.palladiosimulator.experimentautomation.experiments.util.ExperimentsSwitch;
 
@@ -124,6 +125,28 @@ public class ComputeVariantsAndAddExperimentJob extends SequentialBlackboardInte
                                     simulationConfiguration, copy, variationFactorTuples);
                             variationFactorTuples.remove(variationFactorTuples.size() - 1);
                         }
+
+                        iteration++;
+                    }
+                    return null;
+                };
+
+                @Override
+                public Void caseSetValueProvider(final SetValueProvider object) {
+                    final IValueProviderStrategy<Double> valueProvider = ValueProviderFactory
+                            .createDoubleValueProvider(object);
+
+                    int iteration = 0;
+                    while (iteration < variation.getMaxVariations()) {
+                        final Double factorLevel = valueProvider.valueAtPosition(iteration);
+                        if (factorLevel == -1.0) {
+                            break;
+                        }
+
+                        variationFactorTuples.add(new VariationFactorTuple<Double>(variation, factorLevel));
+                        ComputeVariantsAndAddExperimentJob.this.computeVariantsAndAddJob(experiment,
+                                simulationConfiguration, copy, variationFactorTuples);
+                        variationFactorTuples.remove(variationFactorTuples.size() - 1);
 
                         iteration++;
                     }

--- a/bundles/org.palladiosimulator.experimentautomation.application/src/org/palladiosimulator/experimentautomation/application/tooladapter/abstractsimulation/AbstractSimulationConfigFactory.java
+++ b/bundles/org.palladiosimulator.experimentautomation.application/src/org/palladiosimulator/experimentautomation/application/tooladapter/abstractsimulation/AbstractSimulationConfigFactory.java
@@ -166,6 +166,9 @@ public class AbstractSimulationConfigFactory {
 
     private static String getPersistenceRecorder(final EDP2Datasource datasource) {
         final Repository repository = EDP2DatasourceFactory.createOrOpenDatasource(datasource);
+        if (repository == null) {
+            throw new RuntimeException("EDP2DatasourceFactory returned null for datasource: " + datasource);
+        }
         return repository.getId();
     }
 

--- a/bundles/org.palladiosimulator.experimentautomation.application/src/org/palladiosimulator/experimentautomation/application/tooladapter/abstractsimulation/EDP2DatasourceFactory.java
+++ b/bundles/org.palladiosimulator.experimentautomation.application/src/org/palladiosimulator/experimentautomation/application/tooladapter/abstractsimulation/EDP2DatasourceFactory.java
@@ -22,7 +22,10 @@ public class EDP2DatasourceFactory {
      */
     public static Repository createOrOpenDatasource(final EDP2Datasource datasource) {
         if (datasource.getId() != null) {
-            return RepositoryManager.getRepositoryFromUUID(datasource.getId());
+            final Repository existing = RepositoryManager.getRepositoryFromUUID(datasource.getId());
+            if (existing != null) {
+                return existing;
+            }
         }
 
         final Repository repository;

--- a/bundles/org.palladiosimulator.experimentautomation.edit/.project
+++ b/bundles/org.palladiosimulator.experimentautomation.edit/.project
@@ -20,9 +20,26 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121376</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/org.palladiosimulator.experimentautomation.edit/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.edit/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.palladiosimulator.experimentautomation.edit/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.edit/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.palladiosimulator.experimentautomation.editor/.project
+++ b/bundles/org.palladiosimulator.experimentautomation.editor/.project
@@ -20,9 +20,26 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121376</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/org.palladiosimulator.experimentautomation.editor/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.editor/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.palladiosimulator.experimentautomation.editor/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.editor/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.palladiosimulator.experimentautomation.examples.espresso/.project
+++ b/bundles/org.palladiosimulator.experimentautomation.examples.espresso/.project
@@ -15,8 +15,25 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121377</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/org.palladiosimulator.experimentautomation.examples.espresso/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.examples.espresso/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.palladiosimulator.experimentautomation.examples.espresso/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation.examples.espresso/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/Experiments/SimpleVariation.experiments
+++ b/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/Experiments/SimpleVariation.experiments
@@ -8,7 +8,7 @@
     <toolConfiguration xsi:type="simulizartooladapter:SimuLizarConfiguration" name="EDP2 SimuLizar Configuration">
       <stopConditions xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:MeasurementCountStopCondition" measurementCount="1000"/>
       <stopConditions xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:SimTimeStopCondition" simulationTime="-1"/>
-      <datasource xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:MemoryDatasource"/>
+      <datasource xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:FileDatasource" id="" location="/data"/>
     </toolConfiguration>
     <stopConditions xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:MeasurementCountStopCondition" measurementCount="100"/>
     <stopConditions xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:SimTimeStopCondition" simulationTime="-1"/>
@@ -19,6 +19,7 @@
       <allocation href="../default.allocation#_JiPBICHdEd6lJo4DCALHMw"/>
       <middlewareRepository href="pathmap://PCM_MODELS/Glassfish.repository#_yQk9oIX1EdyWta7nHuXiHQ"/>
       <eventMiddleWareRepository href="pathmap://PCM_MODELS/default_event_middleware.repository#_Onc7cMALEd-LKvNtxXAQbQ"/>
+      <monitorRepository href="../espresso.monitorrepository#_ysXQINV8EeSaPsLvWUqTbQ"/>
     </initialModel>
   </experiments>
 </ExperimentAutomation.Experiments:ExperimentRepository>

--- a/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/Experiments/SimpleVariation.experiments
+++ b/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/Experiments/SimpleVariation.experiments
@@ -8,7 +8,7 @@
     <toolConfiguration xsi:type="simulizartooladapter:SimuLizarConfiguration" name="EDP2 SimuLizar Configuration">
       <stopConditions xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:MeasurementCountStopCondition" measurementCount="1000"/>
       <stopConditions xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:SimTimeStopCondition" simulationTime="-1"/>
-      <datasource xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:FileDatasource" id="" location="/data"/>
+      <datasource xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:MemoryDatasource"/>
     </toolConfiguration>
     <stopConditions xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:MeasurementCountStopCondition" measurementCount="100"/>
     <stopConditions xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:SimTimeStopCondition" simulationTime="-1"/>

--- a/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/Experiments/SimpleVariation.experiments
+++ b/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/Experiments/SimpleVariation.experiments
@@ -8,7 +8,7 @@
     <toolConfiguration xsi:type="simulizartooladapter:SimuLizarConfiguration" name="EDP2 SimuLizar Configuration">
       <stopConditions xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:MeasurementCountStopCondition" measurementCount="1000"/>
       <stopConditions xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:SimTimeStopCondition" simulationTime="-1"/>
-      <datasource xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:MemoryDatasource"/>
+      <datasource xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:FileDatasource" location="/data"/>
     </toolConfiguration>
     <stopConditions xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:MeasurementCountStopCondition" measurementCount="100"/>
     <stopConditions xsi:type="ExperimentAutomation.Experiments.AbstractSimulation:SimTimeStopCondition" simulationTime="-1"/>

--- a/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/espresso.measuringpoint
+++ b/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/espresso.measuringpoint
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <org.palladiosimulator.edp2.models:MeasuringPointRepository xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:org.palladiosimulator.edp2.models="http://palladiosimulator.org/EDP2/MeasuringPoint/1.0" xmlns:pcmmeasuringpoint="http://palladiosimulator.org/PCM/MeasuringPoint/1.0" id="_OuW7QNV9EeSaPsLvWUqTbQ">
-  <measuringPoints xsi:type="pcmmeasuringpoint:UsageScenarioMeasuringPoint">
+  <measuringPoints xsi:type="pcmmeasuringpoint:UsageScenarioMeasuringPoint" stringRepresentation="Usage Scenario: EspressoOrderingUsageScenario" resourceURIRepresentation="platform:/resource/org.palladiosimulator.experimentautomation.examples.espresso/model/default.usagemodel#_LPnI8CHdEd6lJo4DCALHMw">
     <usageScenario href="default.usagemodel#_LPnI8CHdEd6lJo4DCALHMw"/>
   </measuringPoints>
 </org.palladiosimulator.edp2.models:MeasuringPointRepository>

--- a/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/espresso.monitorrepository
+++ b/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/espresso.monitorrepository
@@ -3,6 +3,7 @@
   <monitors id="_HbTkYNV9EeSaPsLvWUqTbQ" entityName="Response Times - Usage Scenario">
     <measurementSpecifications id="_a5IPANV9EeSaPsLvWUqTbQ">
       <metricDescription xsi:type="metricspec:NumericalBaseMetricDescription" href="pathmap://METRIC_SPEC_MODELS/models/commonMetrics.metricspec#_6rYmYs7nEeOX_4BzImuHbA"/>
+      <processingType xsi:type="monitorrepository:FeedThrough" id="_9gjRQHCfEfGj7_6MAE23qQ"/>
     </measurementSpecifications>
     <measuringPoint xsi:type="pcmmeasuringpoint:UsageScenarioMeasuringPoint" href="espresso.measuringpoint#//@measuringPoints.0"/>
   </monitors>

--- a/bundles/org.palladiosimulator.experimentautomation/.project
+++ b/bundles/org.palladiosimulator.experimentautomation/.project
@@ -25,11 +25,28 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.sirius.nature.modelingproject</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>net.sourceforge.metrics.nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121363</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/bundles/org.palladiosimulator.experimentautomation/.settings/org.eclipse.core.resources.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/bundles/org.palladiosimulator.experimentautomation/.settings/org.eclipse.m2e.core.prefs
+++ b/bundles/org.palladiosimulator.experimentautomation/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/features/.project
+++ b/features/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>features</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121363</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/features/.settings/org.eclipse.core.resources.prefs
+++ b/features/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/.settings/org.eclipse.m2e.core.prefs
+++ b/features/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/features/org.palladiosimulator.experimentautomation.application.feature/.project
+++ b/features/org.palladiosimulator.experimentautomation.application.feature/.project
@@ -10,8 +10,25 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121365</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/features/org.palladiosimulator.experimentautomation.application.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.palladiosimulator.experimentautomation.application.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.palladiosimulator.experimentautomation.application.feature/.settings/org.eclipse.m2e.core.prefs
+++ b/features/org.palladiosimulator.experimentautomation.application.feature/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/features/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.feature/.project
+++ b/features/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.feature/.project
@@ -10,8 +10,25 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121368</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/features/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.feature/.settings/org.eclipse.m2e.core.prefs
+++ b/features/org.palladiosimulator.experimentautomation.application.tooladapter.simucom.feature/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/features/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.feature/.project
+++ b/features/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.feature/.project
@@ -10,8 +10,25 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121372</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/features/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.feature/.settings/org.eclipse.m2e.core.prefs
+++ b/features/org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.feature/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/features/org.palladiosimulator.experimentautomation.examples.feature/.project
+++ b/features/org.palladiosimulator.experimentautomation.examples.feature/.project
@@ -10,8 +10,25 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121378</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/features/org.palladiosimulator.experimentautomation.examples.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.palladiosimulator.experimentautomation.examples.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.palladiosimulator.experimentautomation.examples.feature/.settings/org.eclipse.m2e.core.prefs
+++ b/features/org.palladiosimulator.experimentautomation.examples.feature/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/features/org.palladiosimulator.experimentautomation.feature/.project
+++ b/features/org.palladiosimulator.experimentautomation.feature/.project
@@ -10,8 +10,25 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.FeatureNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121379</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/features/org.palladiosimulator.experimentautomation.feature/.settings/org.eclipse.core.resources.prefs
+++ b/features/org.palladiosimulator.experimentautomation.feature/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/features/org.palladiosimulator.experimentautomation.feature/.settings/org.eclipse.m2e.core.prefs
+++ b/features/org.palladiosimulator.experimentautomation.feature/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/fix-pcm-bundles.sh
+++ b/fix-pcm-bundles.sh
@@ -1,0 +1,135 @@
+#!/bin/bash
+# Fix PCM OSGi bundle misconfiguration after Eclipse auto-update.
+# 
+# The Eclipse p2 reconciler sometimes upgrades xtend.lib, xbase.lib, Guava,
+# Guice, and MWE bundles to versions that are incompatible with the rest of
+# the Xtext 2.30.0 stack that PCM 5.2.2 ships with.
+#
+# This script reverts those bundles to the known-good versions.
+
+PCM_APP="${1:-/Applications/PCM.app}"
+PLUGINS="$PCM_APP/Contents/Eclipse/plugins"
+BUNDLES_INFO="$PCM_APP/Contents/Eclipse/configuration/org.eclipse.equinox.simpleconfigurator/bundles.info"
+BACKUP_DIR="/tmp/pcm-bundle-fix-$(date +%Y%m%d-%H%M%S)"
+
+# Known-good versions (Eclipse 2023-03 / Xtext 2.30.0)
+GOOD_VERSIONS=(
+  "org.eclipse.xtend.lib:2.30.0.v20230227-1111"
+  "org.eclipse.xtend.lib.macro:2.30.0.v20230227-1111"
+  "org.eclipse.xtext.xbase.lib:2.30.0.v20230227-1111"
+  "com.google.guava:30.1.0.v20221112-0806"
+  "com.google.inject:5.0.1.v20221112-0806"
+  "org.eclipse.emf.mwe.core:1.8.0.v20221117-1134"
+  "org.eclipse.emf.mwe.utils:1.8.0.v20221117-1134"
+  "org.eclipse.emf.mwe2.runtime:2.14.0.v20221117-1134"
+)
+
+# Bundles to REMOVE if present (auto-updated versions that break resolution)
+BAD_SYMLINKS=(
+  "org.eclipse.xtend.lib"
+  "org.eclipse.xtend.lib.macro"
+  "org.eclipse.xtext.xbase.lib"
+  "com.google.guava"
+  "com.google.guava.failureaccess"
+  "com.google.inject"
+  "org.eclipse.emf.mwe.core"
+  "org.eclipse.emf.mwe.utils"
+  "org.eclipse.emf.mwe2.runtime"
+)
+
+echo "PCM: $PCM_APP"
+echo "Backup: $BACKUP_DIR"
+mkdir -p "$BACKUP_DIR"
+cp "$BUNDLES_INFO" "$BACKUP_DIR/bundles.info.bak"
+
+# --- Step 1: Remove bad versions ---
+echo ""
+echo "=== Step 1: Removing auto-updated bundles ==="
+for symname in "${BAD_SYMLINKS[@]}"; do
+  # Find jars that DON'T match the good version
+  for jar in "$PLUGINS/$symname"*.jar; do
+    [ -f "$jar" ] || continue
+    basename "$jar"
+  done
+done
+
+# --- Step 2: Restore good jars ---
+# Good jars should already be on disk (Eclipse keeps old versions).
+# We just need to remove the bad ones.
+echo ""
+echo "=== Step 2: Cleaning bad jars ==="
+for jar in "$PLUGINS"/org.eclipse.xtend.lib_*.jar \
+           "$PLUGINS"/org.eclipse.xtend.lib.macro_*.jar \
+           "$PLUGINS"/org.eclipse.xtext.xbase.lib_*.jar \
+           "$PLUGINS"/com.google.guava_*.jar \
+           "$PLUGINS"/com.google.guava.failureaccess_*.jar \
+           "$PLUGINS"/com.google.inject_*.jar \
+           "$PLUGINS"/org.eclipse.emf.mwe.core_*.jar \
+           "$PLUGINS"/org.eclipse.emf.mwe.utils_*.jar \
+           "$PLUGINS"/org.eclipse.emf.mwe2.runtime_*.jar; do
+  [ -f "$jar" ] || continue
+  jar_name=$(basename "$jar")
+  # Check if there's a version 2.43.0, 33.x, 7.0.0, 1.20.0, 2.26.0 pattern
+  if echo "$jar_name" | grep -qE "_(2\.43\.0\.|33\.|7\.0\.0,|1\.20\.0\.|2\.26\.0\.)"; then
+    echo "  Removing: $jar_name"
+    mv "$jar" "$BACKUP_DIR/"
+  fi
+done
+
+# Also handle the case where both 30.1.0 and 33.6.0 exist - keep 30.1.0
+for jar in "$PLUGINS"/com.google.guava_*.jar; do
+  [ -f "$jar" ] || continue
+  if echo "$(basename "$jar")" | grep -q "33\.6\.0"; then
+    echo "  Removing old Guava 33.x: $(basename "$jar")"
+    mv "$jar" "$BACKUP_DIR/"
+  fi
+done
+
+# --- Step 3: Fix bundles.info ---
+echo ""
+echo "=== Step 3: Fixing bundles.info ==="
+BUNDLES_INFO_NEW="$BACKUP_DIR/bundles.info.fixed"
+cp "$BUNDLES_INFO" "$BUNDLES_INFO_NEW"
+
+# Remove entries for bad versions
+for entry in "org.eclipse.xtend.lib,2.43.0" \
+             "org.eclipse.xtend.lib.macro,2.43.0" \
+             "org.eclipse.xtext.xbase.lib,2.43.0" \
+             "com.google.guava,33.6.0.jre" \
+             "com.google.guava.failureaccess" \
+             "com.google.inject,7.0.0" \
+             "org.eclipse.emf.mwe.core,1.20.0" \
+             "org.eclipse.emf.mwe.utils,1.20.0" \
+             "org.eclipse.emf.mwe2.runtime,2.26.0"; do
+  grep -v "^$entry" "$BUNDLES_INFO_NEW" > "${BUNDLES_INFO_NEW}.tmp"
+  mv "${BUNDLES_INFO_NEW}.tmp" "$BUNDLES_INFO_NEW"
+done
+
+# Check if good versions are already present; add if missing
+declare -A GOOD_MAP
+GOOD_MAP["org.eclipse.xtend.lib"]="org.eclipse.xtend.lib,2.30.0.v20230227-1111,plugins/org.eclipse.xtend.lib_2.30.0.v20230227-1111.jar,4,false"
+GOOD_MAP["org.eclipse.xtend.lib.macro"]="org.eclipse.xtend.lib.macro,2.30.0.v20230227-1111,plugins/org.eclipse.xtend.lib.macro_2.30.0.v20230227-1111.jar,4,false"
+GOOD_MAP["org.eclipse.xtext.xbase.lib"]="org.eclipse.xtext.xbase.lib,2.30.0.v20230227-1111,plugins/org.eclipse.xtext.xbase.lib_2.30.0.v20230227-1111.jar,4,false"
+GOOD_MAP["com.google.guava"]="com.google.guava,30.1.0.v20221112-0806,plugins/com.google.guava_30.1.0.v20221112-0806.jar,4,false"
+GOOD_MAP["org.eclipse.emf.mwe.core"]="org.eclipse.emf.mwe.core,1.8.0.v20221117-1134,plugins/org.eclipse.emf.mwe.core_1.8.0.v20221117-1134.jar,4,false"
+GOOD_MAP["org.eclipse.emf.mwe.utils"]="org.eclipse.emf.mwe.utils,1.8.0.v20221117-1134,plugins/org.eclipse.emf.mwe.utils_1.8.0.v20221117-1134.jar,4,false"
+GOOD_MAP["org.eclipse.emf.mwe2.runtime"]="org.eclipse.emf.mwe2.runtime,2.14.0.v20221117-1134,plugins/org.eclipse.emf.mwe2.runtime_2.14.0.v20221117-1134.jar,4,false"
+
+for symname in "${!GOOD_MAP[@]}"; do
+  if ! grep -q "^$symname," "$BUNDLES_INFO_NEW"; then
+    echo "  Adding missing: $symname"
+    echo "${GOOD_MAP[$symname]}" >> "$BUNDLES_INFO_NEW"
+  fi
+done
+
+cp "$BUNDLES_INFO_NEW" "$BUNDLES_INFO"
+
+# --- Step 4: Clean OSGi cache ---
+echo ""
+echo "=== Step 4: Cleaning OSGi cache ==="
+rm -rf "$PCM_APP/Contents/Eclipse/configuration/org.eclipse.osgi"
+
+echo ""
+echo "=== Done ==="
+echo "Backup in: $BACKUP_DIR"
+echo "Run PCM with -clean flag to rebuild the bundle cache."

--- a/plugin.xml
+++ b/plugin.xml
@@ -1,0 +1,272 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?eclipse version="3.0"?>
+
+<!--
+ Copyright 2005-2009 by SDQ, IPD, University of Karlsruhe, Germany
+-->
+
+<plugin>
+   <extension-point id="stoex_serialiser_provider" name="Stoex Serialiser Provider" schema="schema/stoex_serialiser_provider.exsd"/>
+   <extension-point id="stoex_parser_provider" name="Stoex Parser Provider" schema="schema/stoex_parser_provider.exsd"/>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/5.2"
+            class="org.palladiosimulator.pcm.PcmPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="pcm"
+            class="org.palladiosimulator.pcm.util.PcmResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/Core/5.2"
+            class="org.palladiosimulator.pcm.core.CorePackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="core"
+            class="org.palladiosimulator.pcm.core.util.CoreResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/Core/Entity/5.2"
+            class="org.palladiosimulator.pcm.core.entity.EntityPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="entity"
+            class="org.palladiosimulator.pcm.core.entity.util.EntityResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/Core/Composition/5.2"
+            class="org.palladiosimulator.pcm.core.composition.CompositionPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="composition"
+            class="org.palladiosimulator.pcm.core.composition.util.CompositionResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/UsageModel/5.2"
+            class="org.palladiosimulator.pcm.usagemodel.UsagemodelPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="usagemodel"
+            class="org.palladiosimulator.pcm.usagemodel.util.UsagemodelResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/Repository/5.2"
+            class="org.palladiosimulator.pcm.repository.RepositoryPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="repository"
+            class="org.palladiosimulator.pcm.repository.util.RepositoryResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/ResourceType/5.2"
+            class="org.palladiosimulator.pcm.resourcetype.ResourcetypePackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="resourcetype"
+            class="org.palladiosimulator.pcm.resourcetype.util.ResourcetypeResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/Protocol/5.2"
+            class="org.palladiosimulator.pcm.protocol.ProtocolPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="protocol"
+            class="org.palladiosimulator.pcm.protocol.util.ProtocolResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/Parameter/5.2"
+            class="org.palladiosimulator.pcm.parameter.ParameterPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="parameter"
+            class="org.palladiosimulator.pcm.parameter.util.ParameterResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/Reliability/5.2"
+            class="org.palladiosimulator.pcm.reliability.ReliabilityPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="reliability"
+            class="org.palladiosimulator.pcm.reliability.util.ReliabilityResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/SEFF/5.2"
+            class="org.palladiosimulator.pcm.seff.SeffPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="seff"
+            class="org.palladiosimulator.pcm.seff.util.SeffResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/SEFF/SEFF_Performance/5.2"
+            class="org.palladiosimulator.pcm.seff.seff_performance.SeffPerformancePackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="seffperformance"
+            class="org.palladiosimulator.pcm.seff.seff_performance.util.SeffPerformanceResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/SEFF/SEFF_Reliability/5.2"
+            class="org.palladiosimulator.pcm.seff.seff_reliability.SeffReliabilityPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="seffreliability"
+            class="org.palladiosimulator.pcm.seff.seff_reliability.util.SeffReliabilityResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/QoSAnnotations/5.2"
+            class="org.palladiosimulator.pcm.qosannotations.QosannotationsPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="qosannotations"
+            class="org.palladiosimulator.pcm.qosannotations.util.QosannotationsResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/QoSAnnotations/QoS_Performance/5.2"
+            class="org.palladiosimulator.pcm.qosannotations.qos_performance.QosPerformancePackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="qosperformance"
+            class="org.palladiosimulator.pcm.qosannotations.qos_performance.util.QosPerformanceResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/QoSAnnotations/QoS_Reliability/5.2"
+            class="org.palladiosimulator.pcm.qosannotations.qos_reliability.QosReliabilityPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="qosreliability"
+            class="org.palladiosimulator.pcm.qosannotations.qos_reliability.util.QosReliabilityResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/System/5.2"
+            class="org.palladiosimulator.pcm.system.SystemPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="system"
+            class="org.palladiosimulator.pcm.system.util.SystemResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/ResourceEnvironment/5.2"
+            class="org.palladiosimulator.pcm.resourceenvironment.ResourceenvironmentPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="resourceenvironment"
+            class="org.palladiosimulator.pcm.resourceenvironment.util.ResourceenvironmentResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/Allocation/5.2"
+            class="org.palladiosimulator.pcm.allocation.AllocationPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="allocation"
+            class="org.palladiosimulator.pcm.allocation.util.AllocationResourceFactoryImpl"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.generated_package">
+      <package
+            uri="http://palladiosimulator.org/PalladioComponentModel/SubSystem/5.2"
+            class="org.palladiosimulator.pcm.subsystem.SubsystemPackage"
+            genModel="model/pcm.genmodel"/>
+   </extension>
+
+   <extension point="org.eclipse.emf.ecore.extension_parser">
+      <parser
+            type="subsystem"
+            class="org.palladiosimulator.pcm.subsystem.util.SubsystemResourceFactoryImpl"/>
+   </extension>
+
+</plugin>

--- a/releng/.project
+++ b/releng/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>releng</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121381</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/releng/.settings/org.eclipse.core.resources.prefs
+++ b/releng/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/releng/.settings/org.eclipse.m2e.core.prefs
+++ b/releng/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/.dockerignore
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/.dockerignore
@@ -1,0 +1,2 @@
+# Ignore everything – we use git clone inside the container
+*

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/.dockerignore
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/.dockerignore
@@ -1,2 +1,6 @@
 # Ignore everything – we use git clone inside the container
+# But allow the entrypoint script and Dockerfile (needed when
+# building with this directory as build context)
 *
+!/docker-entrypoint.sh
+!/Dockerfile

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/AGENTS.md
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/AGENTS.md
@@ -56,7 +56,7 @@ a Linux amd64 Docker container. Two GitHub repos are built from source:
 | Arg | Default | Description |
 |---|---|---|
 | `EA_BRANCH` | `product-module` | Branch of ExperimentAutomation to build |
-| `MAVEN_VERSION` | `3.9.9` | Apache Maven version |
+| `MAVEN_VERSION` | `3.9.16` | Apache Maven version |
 
 ## Build & extract
 
@@ -69,9 +69,9 @@ docker build \
   -f releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile \
   .
 
-# Output
-ls -lh target/docker-product/
-# → ExperimentAutomation-linux.gtk.x86_64.tar.gz
+# Output (note nested "product/" directory due to COPY --from)
+ls -lh target/docker-product/product/
+# → ExperimentAutomation-linux.gtk.x86_64.tar.gz  (~170 MB)
 ```
 
 On macOS (Apple Silicon), install QEMU binfmt support first:
@@ -104,7 +104,7 @@ The Docker build has network access to:
 ## Known issues
 
 - **First build is slow**: Maven downloads all dependencies from scratch
-  (no local cache). Expect 30+ minutes.
+  (no local cache). Expect ~8 minutes for AT + ~6 minutes for EA.
 - **QEMU emulation on ARM**: building `--platform linux/amd64` on Apple
   Silicon requires QEMU binfmt and is ~2× slower than native.
 - **No Maven cache volume**: each build starts from scratch. Add
@@ -113,3 +113,12 @@ The Docker build has network access to:
   GitHub, Maven Central).
 - **AT merge must be conflict-free**: the two AT branches must not touch
   the same files. Currently they are disjoint.
+
+## Status (2026-06-25)
+
+- **Build verified**: Docker build on macOS (Apple Silicon, QEMU emulated
+  linux/amd64) completed successfully.
+- **Timing**: ~6.5 min total (AT: 4.5 min, EA: 4.5 min + 2 min product)
+- **Output**: `ExperimentAutomation-linux.gtk.x86_64.tar.gz` (~168 MB)
+- **Contents verified**: SSJ engine (`ca.umontreal.iro.simul.ssj` +
+  `abstractsimengine.ssj`) bundled in the product.

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/AGENTS.md
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/AGENTS.md
@@ -47,8 +47,10 @@ a Linux amd64 Docker container. Two GitHub repos are built from source:
 ## Key files
 
 - `Dockerfile` – 3-stage multi-repo build
+- `docker-entrypoint.sh` – starts Xvfb (SWT/GTK headless), runs Eclipse, propagates exit code; uses `/data` as workspace, `EA_CONSOLE_LOG` env var
 - `pom.xml` – Maven module (pom-packaging, not built by Tycho)
 - `.dockerignore` – ignores everything (we use git clone)
+- `README.md` – Build- und Run-Anleitung (deutsch)
 - `AGENTS.md` – this file
 
 ## Build arguments
@@ -114,11 +116,49 @@ The Docker build has network access to:
 - **AT merge must be conflict-free**: the two AT branches must not touch
   the same files. Currently they are disjoint.
 
+## Usage
+
+```bash
+# Run a headless experiment with workspace persistence
+docker run --rm --platform linux/amd64 \
+  -v /host/path/to/experiments:/experiments:ro \
+  -v /host/path/to/data:/data \
+  experiment-automation:latest \
+  /experiments/my-experiment.experiments
+```
+
+- `/data` – Eclipse-Workspace (Logs, Ergebnisse); via `-v` persistierbar
+- `EA_CONSOLE_LOG=true` – aktiviert `-consoleLog` (Eclipse-Log auf stderr)
+
+The `.experiments` file and any referenced models must be mounted so that
+relative paths inside the experiment file resolve correctly. Example with
+the included espresso model:
+
+```bash
+docker run --rm --platform linux/amd64 \
+  -v /path/to/espresso/model:/experiments:ro \
+  -v /tmp/ea-data:/data \
+  experiment-automation:latest \
+  /experiments/Experiments/SimpleVariation.experiments
+```
+
+Exit code 0 means the simulation completed successfully. See
+`/data/.metadata/.log` for details on errors.
+
+## Runtime dependencies
+
+- **Xvfb** (virtual framebuffer) — the product includes UI bundles (Xtext,
+  Eclipse IDE) that cascade into SWT/GTK initialisation even in headless
+  mode. Xvfb satisfies those dependencies.
+- **libgtk-3-0** — required by SWT.
+
 ## Status (2026-06-25)
 
 - **Build verified**: Docker build on macOS (Apple Silicon, QEMU emulated
   linux/amd64) completed successfully.
-- **Timing**: ~6.5 min total (AT: 4.5 min, EA: 4.5 min + 2 min product)
+- **Runtime verified**: headless experiment runs with exit code 0.
 - **Output**: `ExperimentAutomation-linux.gtk.x86_64.tar.gz` (~168 MB)
 - **Contents verified**: SSJ engine (`ca.umontreal.iro.simul.ssj` +
   `abstractsimengine.ssj`) bundled in the product.
+- **Configuration**: Workspace unter `/data` (bind-mount), Console-Log via
+  `EA_CONSOLE_LOG=true`.

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/AGENTS.md
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/AGENTS.md
@@ -1,0 +1,115 @@
+# Agent context — Experiment Automation Docker Build
+
+## Purpose
+
+`releng/org.palladiosimulator.experimentautomation.product.docker/` builds a
+standalone Eclipse RCP product of the Palladio Experiment Automation inside
+a Linux amd64 Docker container. Two GitHub repos are built from source:
+
+- **Palladio-Addon-ArchitecturalTemplates** – because the UI constants fix
+  (PR #31) and Tycho bump (PR #33) are not yet deployed to the nightly p2
+  updatesite.
+- **Palladio-Addons-ExperimentAutomation** – the product module itself
+  (PR #39, includes Tycho bump).
+
+## Build architecture (3 stages)
+
+```
+┌─────────────────────────────────────────────────────┐
+│ Stage 1: at-builder                                  │
+│ eclipse-temurin:21-jdk-jammy                         │
+│   Install Maven 3.9.9 + git                          │
+│   git clone Palladio-Addon-ArchitecturalTemplates    │
+│   Merge: bump-tycho-to-4.0.13 ← fix/extract-ui-...  │
+│   mvn clean package -DskipTests                      │
+│   → /build/at-repo/ (p2 updatesite)                  │
+└──────────────────────┬──────────────────────────────┘
+                       │ COPY --from=at-builder
+                       ▼
+┌─────────────────────────────────────────────────────┐
+│ Stage 2: ea-builder                                  │
+│ eclipse-temurin:21-jdk-jammy                         │
+│   AT updatesite from stage 1 at /build/at-repo/      │
+│   git clone -b ${EA_BRANCH} ExperimentAutomation     │
+│   Inject local AT repo into product/pom.xml          │
+│   mvn clean package -DskipTests                      │
+│   mvn clean verify -f ...product/pom.xml             │
+│   → /build/ea/releng/...product/target/products/     │
+└──────────────────────┬──────────────────────────────┘
+                       ▼
+┌─────────────────────────────────────────────────────┐
+│ Stage 3: artifact (scratch)                          │
+│   COPY ExperimentAutomation-linux.gtk.x86_64.tar.gz  │
+│   → /product/                                        │
+└─────────────────────────────────────────────────────┘
+```
+
+## Key files
+
+- `Dockerfile` – 3-stage multi-repo build
+- `pom.xml` – Maven module (pom-packaging, not built by Tycho)
+- `.dockerignore` – ignores everything (we use git clone)
+- `AGENTS.md` – this file
+
+## Build arguments
+
+| Arg | Default | Description |
+|---|---|---|
+| `EA_BRANCH` | `product-module` | Branch of ExperimentAutomation to build |
+| `MAVEN_VERSION` | `3.9.9` | Apache Maven version |
+
+## Build & extract
+
+```bash
+# Build – requires linux/amd64 (native or via QEMU)
+docker build \
+  --platform linux/amd64 \
+  --build-arg EA_BRANCH=product-module \
+  --output type=local,dest=./target/docker-product \
+  -f releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile \
+  .
+
+# Output
+ls -lh target/docker-product/
+# → ExperimentAutomation-linux.gtk.x86_64.tar.gz
+```
+
+On macOS (Apple Silicon), install QEMU binfmt support first:
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install amd64
+```
+
+## Git branches referenced by the Docker build
+
+| Repo | Remote ref | Purpose |
+|---|---|---|
+| Palladio-Addon-ArchitecturalTemplates | `origin/bump-tycho-to-4.0.13` | Tycho 2.7.5 → 4.0.13 |
+| Palladio-Addon-ArchitecturalTemplates | `origin/fix/extract-ui-constants-to-separate-class` | UI constants fix (#31) |
+| Palladio-Addons-ExperimentAutomation | `${EA_BRANCH}` (default `product-module`) | Product module + Tycho bump |
+
+The two AT branches are merged inside the Dockerfile; no separate combined
+branch is needed.
+
+## Repositories referenced at build time
+
+The Docker build has network access to:
+
+- GitHub (git clone)
+- Apache Maven (Maven download)
+- Palladio nightly p2 repos (via Maven/Tycho – see target platform and
+  product POM)
+- Eclipse 2023-03 release repo (native launchers)
+
+## Known issues
+
+- **First build is slow**: Maven downloads all dependencies from scratch
+  (no local cache). Expect 30+ minutes.
+- **QEMU emulation on ARM**: building `--platform linux/amd64` on Apple
+  Silicon requires QEMU binfmt and is ~2× slower than native.
+- **No Maven cache volume**: each build starts from scratch. Add
+  `--mount type=volume,src=maven-repo,dst=/root/.m2` for caching.
+- **Network dependency**: build fails without internet access (p2 repos,
+  GitHub, Maven Central).
+- **AT merge must be conflict-free**: the two AT branches must not touch
+  the same files. Currently they are disjoint.

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/AGENTS.md
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/AGENTS.md
@@ -10,7 +10,7 @@ a Linux amd64 Docker container. Two GitHub repos are built from source:
   (PR #31) and Tycho bump (PR #33) are not yet deployed to the nightly p2
   updatesite.
 - **Palladio-Addons-ExperimentAutomation** – the product module itself
-  (PR #39, includes Tycho bump).
+  (PR #39, includes Tycho bump + three critical bugfixes).
 
 ## Build architecture (3 stages)
 
@@ -18,7 +18,7 @@ a Linux amd64 Docker container. Two GitHub repos are built from source:
 ┌─────────────────────────────────────────────────────┐
 │ Stage 1: at-builder                                  │
 │ eclipse-temurin:21-jdk-jammy                         │
-│   Install Maven 3.9.9 + git                          │
+│   Install Maven 3.9.16 + git                         │
 │   git clone Palladio-Addon-ArchitecturalTemplates    │
 │   Merge: bump-tycho-to-4.0.13 ← fix/extract-ui-...  │
 │   mvn clean package -DskipTests                      │
@@ -38,20 +38,38 @@ a Linux amd64 Docker container. Two GitHub repos are built from source:
 └──────────────────────┬──────────────────────────────┘
                        ▼
 ┌─────────────────────────────────────────────────────┐
-│ Stage 3: artifact (scratch)                          │
-│   COPY ExperimentAutomation-linux.gtk.x86_64.tar.gz  │
-│   → /product/                                        │
+│ Stage 3: runtime                                     │
+│ eclipse-temurin:21-jre-jammy                         │
+│   Install GTK3 + Xvfb                                │
+│   Extract product tarball                            │
+│   Strip eclipse.product from config.ini              │
+│   Copy docker-entrypoint.sh                          │
+│   → docker-entrypoint.sh starts Xvfb → runs Eclipse  │
 └─────────────────────────────────────────────────────┘
 ```
 
 ## Key files
 
 - `Dockerfile` – 3-stage multi-repo build
-- `docker-entrypoint.sh` – starts Xvfb (SWT/GTK headless), runs Eclipse, propagates exit code; uses `/data` as workspace, `EA_CONSOLE_LOG` env var
+- `docker-entrypoint.sh` – starts Xvfb (SWT/GTK headless), runs Eclipse,
+   propagates exit code; uses `/data` as workspace, `EA_CONSOLE_LOG` env var
 - `pom.xml` – Maven module (pom-packaging, not built by Tycho)
-- `.dockerignore` – ignores everything (we use git clone)
+- `.dockerignore` – ignores everything except `docker-entrypoint.sh` and
+  `Dockerfile`
 - `README.md` – Build- und Run-Anleitung (deutsch)
 - `AGENTS.md` – this file
+
+## Build
+
+```bash
+docker build \
+  --platform linux/amd64 \
+  -t experiment-automation:latest \
+  -f releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile \
+  .
+```
+
+Build context must be the repository root (`.`), not the docker directory.
 
 ## Build arguments
 
@@ -59,28 +77,7 @@ a Linux amd64 Docker container. Two GitHub repos are built from source:
 |---|---|---|
 | `EA_BRANCH` | `product-module` | Branch of ExperimentAutomation to build |
 | `MAVEN_VERSION` | `3.9.16` | Apache Maven version |
-
-## Build & extract
-
-```bash
-# Build – requires linux/amd64 (native or via QEMU)
-docker build \
-  --platform linux/amd64 \
-  --build-arg EA_BRANCH=product-module \
-  --output type=local,dest=./target/docker-product \
-  -f releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile \
-  .
-
-# Output (note nested "product/" directory due to COPY --from)
-ls -lh target/docker-product/product/
-# → ExperimentAutomation-linux.gtk.x86_64.tar.gz  (~170 MB)
-```
-
-On macOS (Apple Silicon), install QEMU binfmt support first:
-
-```bash
-docker run --privileged --rm tonistiigi/binfmt --install amd64
-```
+| `CACHEBUST` | `1` | Bump to force fresh git clone |
 
 ## Git branches referenced by the Docker build
 
@@ -88,20 +85,32 @@ docker run --privileged --rm tonistiigi/binfmt --install amd64
 |---|---|---|
 | Palladio-Addon-ArchitecturalTemplates | `origin/bump-tycho-to-4.0.13` | Tycho 2.7.5 → 4.0.13 |
 | Palladio-Addon-ArchitecturalTemplates | `origin/fix/extract-ui-constants-to-separate-class` | UI constants fix (#31) |
-| Palladio-Addons-ExperimentAutomation | `${EA_BRANCH}` (default `product-module`) | Product module + Tycho bump |
+| Palladio-Addons-ExperimentAutomation | `${EA_BRANCH}` (default `product-module`) | Product module + Tycho bump + bugfixes |
 
 The two AT branches are merged inside the Dockerfile; no separate combined
 branch is needed.
 
-## Repositories referenced at build time
+## Critical bugfixes on `product-module` branch
 
-The Docker build has network access to:
+1. **`caseSetValueProvider` missing** – `ComputeVariantsAndAddExperimentJob` had
+   no handler for `SetValueProvider` (used by the espresso example). `doSwitch`
+   returned null → no variants created → simulation never ran (exit code 0 but
+   no work done). Fixed by adding `caseSetValueProvider` with direct parsing.
 
-- GitHub (git clone)
-- Apache Maven (Maven download)
-- Palladio nightly p2 repos (via Maven/Tycho – see target platform and
-  product POM)
-- Eclipse 2023-03 release repo (native launchers)
+2. **Stale datasource ID** – `EDP2DatasourceFactory.createOrOpenDatasource()`
+   checked `datasource.getId() != null` and looked up the UUID via
+   `RepositoryManager.getRepositoryFromUUID()`. When the experiment file
+   contained a stale UUID from a previous session (or an empty-string ID),
+   the lookup returned null → `createOrOpenDatasource` returned null → NPE at
+   `getPersistenceRecorder()`. Fixed by falling through to create a fresh
+   repository when the UUID lookup fails.
+
+3. **Long vs Double for ClosedWorkloadVariation** – `SetValueProvider` values
+   like `"1,3,4,5"` were always parsed as `Double` by
+   `SetValueProviderStrategy`. `ClosedWorkloadVariation.vary()` expects `Long`,
+   causing `ClassCastException`. Fixed: `caseSetValueProvider` detects
+   integer-only values with `isAllIntegers()` and creates
+   `VariationFactorTuple<Long>` when appropriate.
 
 ## Known issues
 
@@ -115,11 +124,24 @@ The Docker build has network access to:
   GitHub, Maven Central).
 - **AT merge must be conflict-free**: the two AT branches must not touch
   the same files. Currently they are disjoint.
+- **log4j**: no appenders configured – log output goes to
+  `/data/.metadata/.log` only.
+
+## Status (2026-06-25)
+
+- **Build verified**: Docker build on macOS (Apple Silicon, QEMU emulated
+  linux/amd64) completed successfully.
+- **Runtime verified**: headless experiment runs with exit code 0, all 4
+  SetValueProvider variants executed.
+- **Output**: `ExperimentAutomation-linux.gtk.x86_64.tar.gz` (~168 MB)
+- **Contents verified**: SSJ engine bundled.
+- **Configuration**: Workspace unter `/data` (bind-mount), Console-Log via
+  `EA_CONSOLE_LOG=true`.
+- **espresso example**: `SimpleVariation.experiments` runs to completion.
 
 ## Usage
 
 ```bash
-# Run a headless experiment with workspace persistence
 docker run --rm --platform linux/amd64 \
   -v /host/path/to/experiments:/experiments:ro \
   -v /host/path/to/data:/data \
@@ -130,18 +152,6 @@ docker run --rm --platform linux/amd64 \
 - `/data` – Eclipse-Workspace (Logs, Ergebnisse); via `-v` persistierbar
 - `EA_CONSOLE_LOG=true` – aktiviert `-consoleLog` (Eclipse-Log auf stderr)
 
-The `.experiments` file and any referenced models must be mounted so that
-relative paths inside the experiment file resolve correctly. Example with
-the included espresso model:
-
-```bash
-docker run --rm --platform linux/amd64 \
-  -v /path/to/espresso/model:/experiments:ro \
-  -v /tmp/ea-data:/data \
-  experiment-automation:latest \
-  /experiments/Experiments/SimpleVariation.experiments
-```
-
 Exit code 0 means the simulation completed successfully. See
 `/data/.metadata/.log` for details on errors.
 
@@ -151,14 +161,3 @@ Exit code 0 means the simulation completed successfully. See
   Eclipse IDE) that cascade into SWT/GTK initialisation even in headless
   mode. Xvfb satisfies those dependencies.
 - **libgtk-3-0** — required by SWT.
-
-## Status (2026-06-25)
-
-- **Build verified**: Docker build on macOS (Apple Silicon, QEMU emulated
-  linux/amd64) completed successfully.
-- **Runtime verified**: headless experiment runs with exit code 0.
-- **Output**: `ExperimentAutomation-linux.gtk.x86_64.tar.gz` (~168 MB)
-- **Contents verified**: SSJ engine (`ca.umontreal.iro.simul.ssj` +
-  `abstractsimengine.ssj`) bundled in the product.
-- **Configuration**: Workspace unter `/data` (bind-mount), Console-Log via
-  `EA_CONSOLE_LOG=true`.

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile
@@ -6,7 +6,7 @@
 # =============================================================================
 FROM eclipse-temurin:21-jdk-jammy AS at-builder
 
-ARG MAVEN_VERSION=3.9.9
+ARG MAVEN_VERSION=3.9.16
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl git ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*
@@ -17,9 +17,13 @@ RUN curl -fsSL https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/
 
 WORKDIR /build
 
-# Clone AT, merge both PR branches (Tycho bump + UI constants fix)
-RUN git clone --depth 1 https://github.com/PalladioSimulator/Palladio-Addon-ArchitecturalTemplates.git at \
+# Clone AT, merge both PR branches (Tycho bump + UI constants fix).
+# Full clone (not shallow) needed so git merge can find the common ancestor.
+# Set identity for merge commit (doesn't leave the container).
+RUN git clone https://github.com/PalladioSimulator/Palladio-Addon-ArchitecturalTemplates.git at \
 	&& cd at \
+	&& git config user.email "builder@docker" \
+	&& git config user.name "Docker Builder" \
 	&& git fetch origin bump-tycho-to-4.0.13 fix/extract-ui-constants-to-separate-class \
 	&& git checkout bump-tycho-to-4.0.13 \
 	&& git merge --no-edit origin/fix/extract-ui-constants-to-separate-class
@@ -36,7 +40,7 @@ RUN mkdir -p /build/at-repo && \
 # =============================================================================
 FROM eclipse-temurin:21-jdk-jammy AS ea-builder
 
-ARG MAVEN_VERSION=3.9.9
+ARG MAVEN_VERSION=3.9.16
 ARG EA_BRANCH=product-module
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl git ca-certificates \

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile
@@ -72,9 +72,36 @@ RUN mvn clean package -DskipTests -q
 RUN mvn clean verify -f releng/org.palladiosimulator.experimentautomation.product/pom.xml -q
 
 # =============================================================================
-# Stage 3: Extract product archive (Linux x86_64)
+# Stage 3: Runtime image – product installed + ready to execute
 # =============================================================================
-FROM scratch AS artifact
+FROM eclipse-temurin:21-jre-jammy AS runtime
+
+ARG PRODUCT_ROOT=/opt/experiment-automation
+
+# Install GTK3 + Xvfb so SWT can load in headless containers.
+# The product includes UI bundles (Xtext, Eclipse IDE) that cascade into
+# SWT/Display initialization even for CLI-only workflows.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+	libgtk-3-0 libglib2.0-0 xvfb \
+	&& rm -rf /var/lib/apt/lists/*
+
 COPY --from=ea-builder \
 	/build/ea/releng/org.palladiosimulator.experimentautomation.product/target/products/ExperimentAutomation-linux.gtk.x86_64.tar.gz \
-	/product/
+	/tmp/product.tar.gz
+
+RUN mkdir -p ${PRODUCT_ROOT} && \
+	tar xzf /tmp/product.tar.gz -C ${PRODUCT_ROOT} --strip-components=1 && \
+	rm /tmp/product.tar.gz
+
+# Entrypoint script starts Xvfb, runs Eclipse, propagates exit code.
+COPY releng/org.palladiosimulator.experimentautomation.product.docker/docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Workspace data directory – mount a volume here to persist results / logs.
+#   docker run -v /host/path:/data ...
+VOLUME /data
+
+# Console log output. Set to "true" to enable Eclipse -consoleLog.
+ENV EA_CONSOLE_LOG=
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile
@@ -1,0 +1,76 @@
+# syntax=docker/dockerfile:1
+# SPDX-License-Identifier: MIT
+
+# =============================================================================
+# Stage 1: Build ArchitecturalTemplates from source
+# =============================================================================
+FROM eclipse-temurin:21-jdk-jammy AS at-builder
+
+ARG MAVEN_VERSION=3.9.9
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl git ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+	| tar xz -C /opt && \
+	ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
+
+WORKDIR /build
+
+# Clone AT, merge both PR branches (Tycho bump + UI constants fix)
+RUN git clone --depth 1 https://github.com/PalladioSimulator/Palladio-Addon-ArchitecturalTemplates.git at \
+	&& cd at \
+	&& git fetch origin bump-tycho-to-4.0.13 fix/extract-ui-constants-to-separate-class \
+	&& git checkout bump-tycho-to-4.0.13 \
+	&& git merge --no-edit origin/fix/extract-ui-constants-to-separate-class
+
+WORKDIR /build/at
+RUN mvn clean package -DskipTests -q
+
+# Path to the AT p2 updatesite
+RUN mkdir -p /build/at-repo && \
+	cp -r releng/org.palladiosimulator.architecturaltemplates.updatesite/target/repository/* /build/at-repo/
+
+# =============================================================================
+# Stage 2: Build ExperimentAutomation + product
+# =============================================================================
+FROM eclipse-temurin:21-jdk-jammy AS ea-builder
+
+ARG MAVEN_VERSION=3.9.9
+ARG EA_BRANCH=product-module
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl git ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+
+RUN curl -fsSL https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+	| tar xz -C /opt && \
+	ln -s /opt/apache-maven-${MAVEN_VERSION}/bin/mvn /usr/local/bin/mvn
+
+COPY --from=at-builder /build/at-repo /build/at-repo
+
+WORKDIR /build
+
+RUN git clone --depth 1 --branch ${EA_BRANCH} \
+	https://github.com/PalladioSimulator/Palladio-Addons-ExperimentAutomation.git ea
+
+# Inject local AT p2 repo into the product POM so the director
+# prefers the locally-built AT (newer timestamp) over the nightly
+RUN cd ea && sed -i '/<\/repositories>/i\
+		<repository>\
+			<id>local-at<\/id>\
+			<layout>p2<\/layout>\
+			<url>file:\/\/\/build\/at-repo<\/url>\
+		<\/repository>' \
+		releng/org.palladiosimulator.experimentautomation.product/pom.xml
+
+WORKDIR /build/ea
+RUN mvn clean package -DskipTests -q
+RUN mvn clean verify -f releng/org.palladiosimulator.experimentautomation.product/pom.xml -q
+
+# =============================================================================
+# Stage 3: Extract product archive (Linux x86_64)
+# =============================================================================
+FROM scratch AS artifact
+COPY --from=ea-builder \
+	/build/ea/releng/org.palladiosimulator.experimentautomation.product/target/products/ExperimentAutomation-linux.gtk.x86_64.tar.gz \
+	/product/

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile
@@ -42,6 +42,7 @@ FROM eclipse-temurin:21-jdk-jammy AS ea-builder
 
 ARG MAVEN_VERSION=3.9.16
 ARG EA_BRANCH=product-module
+ARG CACHEBUST=1
 
 RUN apt-get update && apt-get install -y --no-install-recommends curl git ca-certificates \
 	&& rm -rf /var/lib/apt/lists/*
@@ -53,6 +54,9 @@ RUN curl -fsSL https://dlcdn.apache.org/maven/maven-3/${MAVEN_VERSION}/binaries/
 COPY --from=at-builder /build/at-repo /build/at-repo
 
 WORKDIR /build
+
+# CACHEBUST forces a fresh git clone (change value to rebuild)
+RUN echo "cachebuster=${CACHEBUST}"
 
 RUN git clone --depth 1 --branch ${EA_BRANCH} \
 	https://github.com/PalladioSimulator/Palladio-Addons-ExperimentAutomation.git ea
@@ -91,7 +95,11 @@ COPY --from=ea-builder \
 
 RUN mkdir -p ${PRODUCT_ROOT} && \
 	tar xzf /tmp/product.tar.gz -C ${PRODUCT_ROOT} --strip-components=1 && \
-	rm /tmp/product.tar.gz
+	rm /tmp/product.tar.gz && \
+	# Remove eclipse.product from config.ini to suppress
+	# "Product could not be found" (Eclipse has no product extension
+	# registered at runtime; the app runs fine via -application).
+	sed -i '/^eclipse.product=/d' ${PRODUCT_ROOT}/configuration/config.ini
 
 # Entrypoint script starts Xvfb, runs Eclipse, propagates exit code.
 COPY releng/org.palladiosimulator.experimentautomation.product.docker/docker-entrypoint.sh /usr/local/bin/

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/README.md
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/README.md
@@ -1,0 +1,108 @@
+# Experiment Automation – Docker-Image
+
+Dieses Image baut **Palladio Experiment Automation** als standalone Eclipse-RCP-Product inklusive aller Abhängigkeiten (SimuLizar, SimuCom, SSJ-Simulation-Engine, ArchitecturalTemplates) und stellt es als ausführbares Docker-Image bereit.
+
+Zwei Repositories werden aus dem Quellcode gebaut, da die benötigten Fixes noch nicht in den nightly p2-Repos liegen:
+
+- [Palladio-Addon-ArchitecturalTemplates](https://github.com/PalladioSimulator/Palladio-Addon-ArchitecturalTemplates) – UI-Constants-Fix und Tycho-Bump
+- [Palladio-Addons-ExperimentAutomation](https://github.com/PalladioSimulator/Palladio-Addons-ExperimentAutomation) – Product-Module und Tycho-Bump (Branch `product-module`)
+
+## Voraussetzungen
+
+- Docker mit `--platform linux/amd64` Support
+- Auf Apple Silicon (M1/M2/M3): QEMU binfmt einmalig installieren
+
+```bash
+docker run --privileged --rm tonistiigi/binfmt --install amd64
+```
+
+## Bauen
+
+```bash
+docker build \
+  --platform linux/amd64 \
+  -t experiment-automation:latest \
+  -f releng/org.palladiosimulator.experimentautomation.product.docker/Dockerfile \
+  .
+```
+
+Der Build dauert ca. 6–8 Minuten (kein Maven-Cache, Download aller Abhängigkeiten).  
+Der AT-Build kann mit `--build-arg MAVEN_VERSION=<version>` auf eine andere Maven-Version umgestellt werden.
+
+## Ausführen
+
+### Ein Experiment ausführen
+
+Das `.experiments`-File und alle referenzierten Modelle müssen per Bind-Mount eingebunden werden, sodass relative Pfade im Experiment-File korrekt aufgelöst werden können.
+
+Beispiel mit dem Espresso-Beispielmodell:
+
+```bash
+docker run --rm --platform linux/amd64 \
+  -v /pfad/zu/espresso/model/:/experiments:ro \
+  -v /pfad/zu/workspace-data:/data \
+  experiment-automation:latest \
+  /experiments/Experiments/SimpleVariation.experiments
+```
+
+- `/experiments` – beliebiger Mount-Point; das Experiment-File und seine Modelle müssen hier liegen  
+- `/data` – Eclipse-Workspace (Logs, Ergebnisse); wird automatisch erstellt
+
+Exit-Code `0` bedeutet erfolgreiche Durchführung. Bei Fehlern:
+
+```bash
+cat /pfad/zu/workspace-data/.metadata/.log
+```
+
+### Console-Log aktivieren
+
+Standardmäßig wird nur das Nötigste auf der Konsole ausgegeben (EDP2-/log4j-Warnungen).  
+Mit der Umgebungsvariable `EA_CONSOLE_LOG=true` wird das vollständige Eclipse-Log ausgegeben:
+
+```bash
+docker run --rm --platform linux/amd64 \
+  -v /pfad/zu/espresso/model/:/experiments:ro \
+  -e EA_CONSOLE_LOG=true \
+  experiment-automation:latest \
+  /experiments/Experiments/SimpleVariation.experiments
+```
+
+### Image als ausführbares Kommando
+
+```bash
+alias ea-docker='docker run --rm --platform linux/amd64 \
+  -v "$(pwd)/experiments:/experiments:ro" \
+  -v "$(pwd)/ea-data:/data" \
+  experiment-automation:latest'
+
+ea-docker /experiments/setup/mein-experiment.experiments
+```
+
+## Ausgabe
+
+Bei Erfolg erscheint auf der Konsole:
+
+```
+EDP2-Warnung (Neukonfiguration, einmalig)
+log4j-Warnung (kein log4j.properties, harmlos)
+EXIT_CODE=0
+```
+
+Das Workspace-Verzeichnis unter `/data` enthält `.metadata/.log` mit detaillierten Informationen.
+
+## Technische Details
+
+- **Basis-Image**: `eclipse-temurin:21-jre-jammy` (Ubuntu 22.04, OpenJDK 21, ~170 MB Product)
+- **Xvfb**: Notwendig, da das RCP-Product UI-Plugins (Xtext, Eclipse-IDE) bindet, die auch im Headless-Modus SWT/GTK initialisieren
+- **3-Stage-Build**:
+  1. `at-builder` – ArchitecturalTemplates aus Source + p2-Update-Site
+  2. `ea-builder` – ExperimentAutomation + Product-Build
+  3. `runtime` – Runtime-Image mit GTK3, Xvfb und dem Product-Tarball
+- **SSJ-Simulation-Engine** (`ca.umontreal.iro.simul.ssj`) ist im Product enthalten
+
+## Bekannte Probleme
+
+- **Erster Build ist langsam**: Kein Maven-Cache. Wer häufig baut, kann ein Volume mounten: `--mount type=volume,src=maven-repo,dst=/root/.m2`
+- **Kein Internet = kein Build**: p2-Repos, GitHub, Maven Central werden benötigt
+- **QEMU-Emulation**: Auf ARM ~2× langsamer als native AMD64
+- **AT-Branches müssen konfliktfrei sein**: Die beiden gemergten Branches (`bump-tycho-to-4.0.13`, `fix/extract-ui-constants-to-separate-class`) überschneiden sich derzeit nicht

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/README.md
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/README.md
@@ -5,7 +5,7 @@ Dieses Image baut **Palladio Experiment Automation** als standalone Eclipse-RCP-
 Zwei Repositories werden aus dem Quellcode gebaut, da die benötigten Fixes noch nicht in den nightly p2-Repos liegen:
 
 - [Palladio-Addon-ArchitecturalTemplates](https://github.com/PalladioSimulator/Palladio-Addon-ArchitecturalTemplates) – UI-Constants-Fix und Tycho-Bump
-- [Palladio-Addons-ExperimentAutomation](https://github.com/PalladioSimulator/Palladio-Addons-ExperimentAutomation) – Product-Module und Tycho-Bump (Branch `product-module`)
+- [Palladio-Addons-ExperimentAutomation](https://github.com/PalladioSimulator/Palladio-Addons-ExperimentAutomation) – Product-Module, Tycho-Bump und drei kritische Bugfixes (Branch `product-module`)
 
 ## Voraussetzungen
 
@@ -18,6 +18,8 @@ docker run --privileged --rm tonistiigi/binfmt --install amd64
 
 ## Bauen
 
+Build-Kontext ist das Repository-Root:
+
 ```bash
 docker build \
   --platform linux/amd64 \
@@ -26,8 +28,7 @@ docker build \
   .
 ```
 
-Der Build dauert ca. 6–8 Minuten (kein Maven-Cache, Download aller Abhängigkeiten).  
-Der AT-Build kann mit `--build-arg MAVEN_VERSION=<version>` auf eine andere Maven-Version umgestellt werden.
+Der Build dauert ca. 6–8 Minuten (kein Maven-Cache, Download aller Abhängigkeiten).
 
 ## Ausführen
 
@@ -45,7 +46,7 @@ docker run --rm --platform linux/amd64 \
   /experiments/Experiments/SimpleVariation.experiments
 ```
 
-- `/experiments` – beliebiger Mount-Point; das Experiment-File und seine Modelle müssen hier liegen  
+- `/experiments` – beliebiger Mount-Point; das Experiment-File und seine Modelle müssen hier liegen
 - `/data` – Eclipse-Workspace (Logs, Ergebnisse); wird automatisch erstellt
 
 Exit-Code `0` bedeutet erfolgreiche Durchführung. Bei Fehlern:
@@ -56,7 +57,7 @@ cat /pfad/zu/workspace-data/.metadata/.log
 
 ### Console-Log aktivieren
 
-Standardmäßig wird nur das Nötigste auf der Konsole ausgegeben (EDP2-/log4j-Warnungen).  
+Standardmäßig wird nur das Nötigste auf der Konsole ausgegeben (EDP2-/log4j-Warnungen).
 Mit der Umgebungsvariable `EA_CONSOLE_LOG=true` wird das vollständige Eclipse-Log ausgegeben:
 
 ```bash
@@ -99,6 +100,10 @@ Das Workspace-Verzeichnis unter `/data` enthält `.metadata/.log` mit detaillier
   2. `ea-builder` – ExperimentAutomation + Product-Build
   3. `runtime` – Runtime-Image mit GTK3, Xvfb und dem Product-Tarball
 - **SSJ-Simulation-Engine** (`ca.umontreal.iro.simul.ssj`) ist im Product enthalten
+- **Kritische Bugfixes** auf dem `product-module` Branch:
+  - `caseSetValueProvider`-Handler für `SetValueProvider` (fehlte vollständig, Simulation wurde nie gestartet)
+  - `MemoryDatasource`/`FileDatasource`-Reparatur bei leerer/stale ID
+  - Long-Erkennung für `SetValueProvider`-Werte (`ClosedWorkloadVariation` erwartet Long)
 
 ## Bekannte Probleme
 
@@ -106,3 +111,4 @@ Das Workspace-Verzeichnis unter `/data` enthält `.metadata/.log` mit detaillier
 - **Kein Internet = kein Build**: p2-Repos, GitHub, Maven Central werden benötigt
 - **QEMU-Emulation**: Auf ARM ~2× langsamer als native AMD64
 - **AT-Branches müssen konfliktfrei sein**: Die beiden gemergten Branches (`bump-tycho-to-4.0.13`, `fix/extract-ui-constants-to-separate-class`) überschneiden sich derzeit nicht
+- **log4j-Logging**: Keine Appender konfiguriert – Logs erscheinen nur im Workspace-Log (`/data/.metadata/.log`)

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/docker-entrypoint.sh
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/docker-entrypoint.sh
@@ -1,0 +1,33 @@
+#!/bin/sh
+# Entrypoint for experiment-automation Docker image.
+# Starts Xvfb (needed by SWT/GTK even in headless mode), runs Eclipse,
+# and propagates the exit code.
+#
+# Environment variables:
+#   EA_CONSOLE_LOG  Set to "true" to add -consoleLog (logs to stderr)
+
+set -e
+
+XVFB_DISPLAY=:99
+ECLIPSE_ARGS="-nosplash -product org.palladiosimulator.experimentautomation.product -data /data"
+
+if [ "${EA_CONSOLE_LOG}" = "true" ]; then
+    ECLIPSE_ARGS="${ECLIPSE_ARGS} -consoleLog"
+fi
+
+# Start Xvfb
+Xvfb "$XVFB_DISPLAY" -screen 0 1280x1024x24 -nolisten tcp &
+XVFB_PID=$!
+
+export DISPLAY="$XVFB_DISPLAY"
+
+# Run Eclipse; capture exit code
+# shellcheck disable=SC2086
+/opt/experiment-automation/eclipse ${ECLIPSE_ARGS} "$@"
+EC=$?
+
+# Clean up Xvfb
+kill "$XVFB_PID" 2>/dev/null
+wait "$XVFB_PID" 2>/dev/null
+
+exit "$EC"

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/docker-entrypoint.sh
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/docker-entrypoint.sh
@@ -9,7 +9,7 @@
 set -e
 
 XVFB_DISPLAY=:99
-ECLIPSE_ARGS="-nosplash -product org.palladiosimulator.experimentautomation.application.product -data /data"
+ECLIPSE_ARGS="-nosplash -application org.palladiosimulator.experimentautomation.application -data /data"
 
 if [ "${EA_CONSOLE_LOG}" = "true" ]; then
     ECLIPSE_ARGS="${ECLIPSE_ARGS} -consoleLog"

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/docker-entrypoint.sh
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/docker-entrypoint.sh
@@ -9,7 +9,7 @@
 set -e
 
 XVFB_DISPLAY=:99
-ECLIPSE_ARGS="-nosplash -product org.palladiosimulator.experimentautomation.product -data /data"
+ECLIPSE_ARGS="-nosplash -product org.palladiosimulator.experimentautomation.application.product -data /data"
 
 if [ "${EA_CONSOLE_LOG}" = "true" ]; then
     ECLIPSE_ARGS="${ECLIPSE_ARGS} -consoleLog"

--- a/releng/org.palladiosimulator.experimentautomation.product.docker/pom.xml
+++ b/releng/org.palladiosimulator.experimentautomation.product.docker/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.palladiosimulator.experimentautomation</groupId>
+		<artifactId>parent</artifactId>
+		<version>6.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>org.palladiosimulator.experimentautomation.product.docker</artifactId>
+	<packaging>pom</packaging>
+
+	<description>
+		Docker build of the standalone Experiment Automation product.
+		Builds ArchitecturalTemplates and ExperimentAutomation from source
+		within a Linux amd64 container, producing a self-contained
+		Eclipse RCP product archive with all dependencies.
+	</description>
+
+</project>

--- a/releng/org.palladiosimulator.experimentautomation.product/AGENTS.md
+++ b/releng/org.palladiosimulator.experimentautomation.product/AGENTS.md
@@ -56,18 +56,35 @@ from the target platform.
 - **Build**: verified – all 5 platform archives produced (~175 MB each)
 - **SSJ engine**: included and resolved (no more NPE in engine init)
 - **Headless run**: verified via macOS aarch64 product – exit code 0
-- **Example**: `SimpleVariation.experiments` works (from espresso examples)
+- **Example**: `SimpleVariation.experiments` runs through all 4 SetValueProvider
+  variants (1, 3, 4, 5 users) with MemoryDatasource
+
+## Critical fixes on `product-module` branch
+
+- **`caseSetValueProvider`** in `ComputeVariantsAndAddExperimentJob` – the
+  original code had no handler for `SetValueProvider`; `doSwitch` returned null
+  → no variants created → simulation never ran. Fixed by adding a
+  `caseSetValueProvider` that parses values directly (`isAllIntegers`/`getToken`
+  helpers) and uses `Long` or `Double` depending on the actual token format.
+- **Stale datasource ID** in `EDP2DatasourceFactory` – when an experiment file
+  has a pre-existing (stale) datasource UUID, `getRepositoryFromUUID()` returned
+  null for the current JVM session. Fixed by falling through to create a fresh
+  repository when the UUID lookup fails.
+- **`FileDatasource` `/data` fallback** – `FileDatasource` with `location="/data"`
+  fails when `/data` does not exist (permission denied). The example reverts to
+  `MemoryDatasource` which works correctly after the stale-ID fix.
 
 ## Known issues
 
-- **Henshin interpreter**: warning about missing
-  `org.eclipse.emf.henshin.interpreter` (non-fatal, from SimuLizar
-  reconfiguration).
 - **log4j warnings**: missing appenders – harmless, does not affect execution.
+  Simulation progresses can be found in `workspace/.metadata/.log`.
+- **Product not found warning**: cosmetic when using `-application` flag.
 
 ## Related
 
 - `releng/org.palladiosimulator.experimentautomation.updatesite/` –
   produces the p2 repository that this product consumes
+- `releng/org.palladiosimulator.experimentautomation.docker/` –
+  Docker build wrapping this product
 - `releng/org.palladiosimulator.experimentautomation.targetplatform/` –
   Eclipse target definition resolving upstream Palladio repos

--- a/releng/org.palladiosimulator.experimentautomation.product/AGENTS.md
+++ b/releng/org.palladiosimulator.experimentautomation.product/AGENTS.md
@@ -1,0 +1,78 @@
+# Agent context — Experiment Automation Product
+
+## Purpose
+
+`releng/org.palladiosimulator.experimentautomation.product/` builds a
+standalone Eclipse RCP product of the Palladio Experiment Automation,
+bundling the headless experiment application with all dependencies
+(PCM, SimuLizar, SimuCom, SSJ simulation engine, EDP2, etc.) into
+platform-specific archives with native launchers.
+
+Not part of the regular reactor (`releng/pom.xml`).  Built manually via
+`-f ...product/pom.xml`.
+
+## Key files
+
+- `product.product` – Eclipse product definition (`useFeatures="true"`,
+  `includeLaunchers="true"`, application
+  `org.palladiosimulator.experimentautomation.application`)
+- `pom.xml` – `eclipse-repository` packaging, delegates to
+  `tycho-p2-director-plugin` for materialize + archive
+
+## Build order
+
+1. `mvn clean package -DskipTests` (root) → produces updatesite at
+   `releng/...updatesite/target/repository`
+2. `mvn clean verify -f releng/...product/pom.xml` → materialises product
+
+The product POM references these p2 repositories:
+
+| Repo | ID | Purpose |
+|---|---|---|
+| Local updatesite | `local-updatesite` | `file://` to the built EA updatesite |
+| Eclipse 2023-03 | `eclipse-2023-03` | Equinox executable feature (native launchers) |
+| AbstractSimEngine (nightly) | `abstractsimengine` | SSJ + abstractsimengine features/plugins |
+| Third-party wrapper (nightly) | `thirdparty-wrapper` | DESMO-J, Apache Commons Math, etc. |
+| Third-party library (nightly) | `thirdparty-library` | `ca.umontreal.iro.simul.ssj` (SSJ math lib) |
+
+## Product contents
+
+Included features (in order):
+
+- `org.palladiosimulator.pcm.feature` – PCM core (models, resources → pathmap)
+- `org.palladiosimulator.thirdpartywrapper.feature` – DESMO-J, JFreeChart, etc.
+- `ca.umontreal.iro.ssj.feature` – SSJ stochastic simulation library
+- `de.uka.ipd.sdq.simulation.abstractsimengine.feature` – abstract simulation API
+- `org.palladiosimulator.simulation.abstractsimengine.ssj.feature` – SSJ engine impl
+- `org.palladiosimulator.experimentautomation.application.feature` – main app
+- `...application.tooladapter.simulizar.feature` – SimuLizar adapter
+- `...application.tooladapter.simucom.feature` – SimuCom adapter
+
+All transitive dependencies (EMF, Equinox, workflow engine) are resolved
+from the target platform.
+
+## Status (2026-06-25)
+
+- **Build**: verified – all 5 platform archives produced (~175 MB each)
+- **SSJ engine**: included and resolved (no more NPE in engine init)
+- **Headless run**: verified via macOS aarch64 product – exit code 0
+- **Example**: `SimpleVariation.experiments` works (from espresso examples)
+
+## Known issues
+
+- **PCM pathmap** (`pathmap://PCM_MODELS/`) may not resolve at runtime;
+  the product boots and runs but model loading can fail.  Same issue as
+  in PCM.app headless runs.
+- **Henshin interpreter**: warning about missing
+  `org.eclipse.emf.henshin.interpreter` (non-fatal, from SimuLizar
+  reconfiguration).
+- **log4j warnings**: missing appenders – harmless, does not affect execution.
+- **Product branding**: "Product could not be found" message when using
+  `-application` directly – harmless.
+
+## Related
+
+- `releng/org.palladiosimulator.experimentautomation.updatesite/` –
+  produces the p2 repository that this product consumes
+- `releng/org.palladiosimulator.experimentautomation.targetplatform/` –
+  Eclipse target definition resolving upstream Palladio repos

--- a/releng/org.palladiosimulator.experimentautomation.product/AGENTS.md
+++ b/releng/org.palladiosimulator.experimentautomation.product/AGENTS.md
@@ -60,15 +60,10 @@ from the target platform.
 
 ## Known issues
 
-- **PCM pathmap** (`pathmap://PCM_MODELS/`) may not resolve at runtime;
-  the product boots and runs but model loading can fail.  Same issue as
-  in PCM.app headless runs.
 - **Henshin interpreter**: warning about missing
   `org.eclipse.emf.henshin.interpreter` (non-fatal, from SimuLizar
   reconfiguration).
 - **log4j warnings**: missing appenders – harmless, does not affect execution.
-- **Product branding**: "Product could not be found" message when using
-  `-application` directly – harmless.
 
 ## Related
 

--- a/releng/org.palladiosimulator.experimentautomation.product/README.md
+++ b/releng/org.palladiosimulator.experimentautomation.product/README.md
@@ -50,21 +50,23 @@ The product is **not** part of the regular reactor build
 
 ### Via native launcher (macOS example)
 
+Use `-application` (not `-product`) to run headlessly:
+
 ```bash
 ./target/products/ExperimentAutomation/macosx/cocoa/aarch64/experiment-automation.app/Contents/MacOS/eclipse \
-  -product org.palladiosimulator.experimentautomation.product \
+  -application org.palladiosimulator.experimentautomation.application \
   -data /tmp/ea-workspace \
+  -consoleLog \
   /path/to/your/experiment.experiments
 ```
 
-Use a fresh (or empty) `-data` directory each time to avoid workspace lock
-conflicts.
+The `-consoleLog` flag is optional and enables Eclipse log output on stderr.
 
 ### Via `java -jar`
 
 ```bash
 java -jar target/products/ExperimentAutomation/macosx/cocoa/aarch64/experiment-automation.app/Contents/Eclipse/plugins/org.eclipse.equinox.launcher_*.jar \
-  -product org.palladiosimulator.experimentautomation.product \
+  -application org.palladiosimulator.experimentautomation.application \
   -data /tmp/ea-workspace \
   /path/to/your/experiment.experiments
 ```
@@ -76,7 +78,7 @@ The espresso example ships experiment models in the
 
 ```bash
 /path/to/eclipse \
-  -product org.palladiosimulator.experimentautomation.product \
+  -application org.palladiosimulator.experimentautomation.application \
   -data /tmp/ea-workspace \
   /path/to/repo/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/Experiments/SimpleVariation.experiments
 ```
@@ -85,13 +87,15 @@ The espresso example ships experiment models in the
 
 | Argument | Description |
 |---|---|
-| `-product <id>` | Product ID (`org.palladiosimulator.experimentautomation.product`) |
+| `-application <id>` | Application ID (`org.palladiosimulator.experimentautomation.application`) |
 | `-data <dir>` | Eclipse workspace directory (required; arbitrary temp dir is fine) |
+| `-consoleLog` | Print Eclipse log to stderr (optional) |
 | `<file.experiments>` | Path to the experiment repository model (`.experiments` extension) |
 
 ### Known Issues
 
-- **Henshin interpreter**: warning about missing
-  `org.eclipse.emf.henshin.interpreter` (non-fatal, from SimuLizar
-  reconfiguration).
-- **Logging**: log4j warnings about missing appenders are harmless.
+- **log4j warnings**: missing appenders – harmless, does not affect execution.
+  Simulation progress can be checked in `workspace/.metadata/.log`.
+- **Product not found warning**: `Product org.palladiosimulator.experimentautomation.product
+  could not be found.` is cosmetic when using `-application` – the headless
+  application works correctly despite this message.

--- a/releng/org.palladiosimulator.experimentautomation.product/README.md
+++ b/releng/org.palladiosimulator.experimentautomation.product/README.md
@@ -1,0 +1,101 @@
+# Palladio Experiment Automation — Standalone Product
+
+This module builds a standalone Eclipse RCP product of the Palladio Experiment
+Automation.  The product bundles the experiment application plus all transitive
+dependencies (PCM, SimuLizar, SimuCom, SSJ simulation engine, etc.) into a
+self-contained directory with native launchers for all supported platforms.
+
+## Requirements
+
+- JDK 17+ (tested with JDK 21)
+- Maven 3.8+
+- Network access to the Palladio nightly p2 repositories (see `pom.xml`)
+
+## Build
+
+### 1. Build the main project (bundles, features, updatesite)
+
+The product depends on the local updatesite.  Build it first:
+
+```bash
+mvn clean package -DskipTests
+```
+
+### 2. Build the product
+
+```bash
+mvn clean verify -f releng/org.palladiosimulator.experimentautomation.product/pom.xml
+```
+
+The product is materialised and archived for every platform in:
+
+```
+releng/org.palladiosimulator.experimentautomation.product/target/products/
+```
+
+Output per platform (~175 MB each):
+
+| Platform | Archive |
+|---|---|
+| macOS x86\_64 | `ExperimentAutomation-macosx.cocoa.x86_64.tar.gz` / `.app` |
+| macOS aarch64 | `ExperimentAutomation-macosx.cocoa.aarch64.tar.gz` / `.app` |
+| Linux x86\_64 | `ExperimentAutomation-linux.gtk.x86_64.tar.gz` |
+| Linux aarch64 | `ExperimentAutomation-linux.gtk.aarch64.tar.gz` |
+| Windows x86\_64 | `ExperimentAutomation-win32.win32.x86_64.zip` |
+
+The product is **not** part of the regular reactor build
+(`releng/pom.xml`).  It must be built manually as shown above.
+
+## Run
+
+### Via native launcher (macOS example)
+
+```bash
+./target/products/ExperimentAutomation/macosx/cocoa/aarch64/experiment-automation.app/Contents/MacOS/eclipse \
+  -application org.palladiosimulator.experimentautomation.application \
+  -data /tmp/ea-workspace \
+  /path/to/your/experiment.experiments
+```
+
+Use a fresh (or empty) `-data` directory each time to avoid workspace lock
+conflicts.
+
+### Via `java -jar`
+
+```bash
+java -jar target/products/ExperimentAutomation/macosx/cocoa/aarch64/experiment-automation.app/Contents/Eclipse/plugins/org.eclipse.equinox.launcher_*.jar \
+  -application org.palladiosimulator.experimentautomation.application \
+  -data /tmp/ea-workspace \
+  /path/to/your/experiment.experiments
+```
+
+### Example
+
+The espresso example ships experiment models in the
+`org.palladiosimulator.experimentautomation.examples.espresso` bundle:
+
+```bash
+/path/to/eclipse \
+  -application org.palladiosimulator.experimentautomation.application \
+  -data /tmp/ea-workspace \
+  /path/to/repo/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/Experiments/SimpleVariation.experiments
+```
+
+### Arguments
+
+| Argument | Description |
+|---|---|
+| `-data <dir>` | Eclipse workspace directory (required; arbitrary temp dir is fine) |
+| `<file.experiments>` | Path to the experiment repository model (`.experiments` extension) |
+
+### Known Issues
+
+- **PCM pathmap resolution**: `pathmap://PCM_MODELS/` URIs may fail if the
+  PCM model bundle is not fully initialised.  This is a pre-existing issue
+  that also affects PCM.app headless runs.
+- **Henshin interpreter**: warning about missing
+  `org.eclipse.emf.henshin.interpreter` (non-fatal, from SimuLizar
+  reconfiguration).
+- **Logging**: log4j warnings about missing appenders are harmless.
+- **Product branding**: the message "Product could not be found" on startup
+  is harmless when using `-application` directly.

--- a/releng/org.palladiosimulator.experimentautomation.product/README.md
+++ b/releng/org.palladiosimulator.experimentautomation.product/README.md
@@ -52,7 +52,7 @@ The product is **not** part of the regular reactor build
 
 ```bash
 ./target/products/ExperimentAutomation/macosx/cocoa/aarch64/experiment-automation.app/Contents/MacOS/eclipse \
-  -application org.palladiosimulator.experimentautomation.application \
+  -product org.palladiosimulator.experimentautomation.product \
   -data /tmp/ea-workspace \
   /path/to/your/experiment.experiments
 ```
@@ -64,7 +64,7 @@ conflicts.
 
 ```bash
 java -jar target/products/ExperimentAutomation/macosx/cocoa/aarch64/experiment-automation.app/Contents/Eclipse/plugins/org.eclipse.equinox.launcher_*.jar \
-  -application org.palladiosimulator.experimentautomation.application \
+  -product org.palladiosimulator.experimentautomation.product \
   -data /tmp/ea-workspace \
   /path/to/your/experiment.experiments
 ```
@@ -76,7 +76,7 @@ The espresso example ships experiment models in the
 
 ```bash
 /path/to/eclipse \
-  -application org.palladiosimulator.experimentautomation.application \
+  -product org.palladiosimulator.experimentautomation.product \
   -data /tmp/ea-workspace \
   /path/to/repo/bundles/org.palladiosimulator.experimentautomation.examples.espresso/model/Experiments/SimpleVariation.experiments
 ```
@@ -85,17 +85,13 @@ The espresso example ships experiment models in the
 
 | Argument | Description |
 |---|---|
+| `-product <id>` | Product ID (`org.palladiosimulator.experimentautomation.product`) |
 | `-data <dir>` | Eclipse workspace directory (required; arbitrary temp dir is fine) |
 | `<file.experiments>` | Path to the experiment repository model (`.experiments` extension) |
 
 ### Known Issues
 
-- **PCM pathmap resolution**: `pathmap://PCM_MODELS/` URIs may fail if the
-  PCM model bundle is not fully initialised.  This is a pre-existing issue
-  that also affects PCM.app headless runs.
 - **Henshin interpreter**: warning about missing
   `org.eclipse.emf.henshin.interpreter` (non-fatal, from SimuLizar
   reconfiguration).
 - **Logging**: log4j warnings about missing appenders are harmless.
-- **Product branding**: the message "Product could not be found" on startup
-  is harmless when using `-application` directly.

--- a/releng/org.palladiosimulator.experimentautomation.product/pom.xml
+++ b/releng/org.palladiosimulator.experimentautomation.product/pom.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>org.palladiosimulator.experimentautomation</groupId>
+		<artifactId>parent</artifactId>
+		<version>6.0.0-SNAPSHOT</version>
+		<relativePath>../../pom.xml</relativePath>
+	</parent>
+	<artifactId>org.palladiosimulator.experimentautomation.product</artifactId>
+	<packaging>eclipse-repository</packaging>
+
+	<repositories>
+		<repository>
+			<id>local-updatesite</id>
+			<layout>p2</layout>
+			<url>file://${project.basedir}/../org.palladiosimulator.experimentautomation.updatesite/target/repository</url>
+		</repository>
+		<repository>
+			<id>eclipse-2023-03</id>
+			<layout>p2</layout>
+			<url>https://download.eclipse.org/releases/2023-03/</url>
+		</repository>
+		<repository>
+			<id>abstractsimengine</id>
+			<layout>p2</layout>
+			<url>https://updatesite.palladio-simulator.com/palladio-simulation-abstractsimengine/nightly/</url>
+		</repository>
+		<repository>
+			<id>thirdparty-wrapper</id>
+			<layout>p2</layout>
+			<url>https://updatesite.palladio-simulator.com/palladio-thirdparty-wrapper/nightly/</url>
+		</repository>
+		<repository>
+			<id>thirdparty-library</id>
+			<layout>p2</layout>
+			<url>https://updatesite.palladio-simulator.com/palladio-thirdparty-library/nightly/</url>
+		</repository>
+	</repositories>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.eclipse.tycho</groupId>
+				<artifactId>tycho-p2-director-plugin</artifactId>
+				<version>${tycho.version}</version>
+				<executions>
+					<execution>
+						<id>materialize-products</id>
+						<goals>
+							<goal>materialize-products</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>archive-products</id>
+						<goals>
+							<goal>archive-products</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<products>
+						<product>
+							<id>ExperimentAutomation</id>
+							<rootFolder>experiment-automation</rootFolder>
+						</product>
+					</products>
+				</configuration>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/releng/org.palladiosimulator.experimentautomation.product/product.product
+++ b/releng/org.palladiosimulator.experimentautomation.product/product.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 <product name="Palladio Experiment Automation" uid="ExperimentAutomation"
-         id="org.palladiosimulator.experimentautomation.application.product"
+         id="org.palladiosimulator.experimentautomation.product"
          application="org.palladiosimulator.experimentautomation.application"
          version="6.0.0.qualifier" useFeatures="true" includeLaunchers="true">
 

--- a/releng/org.palladiosimulator.experimentautomation.product/product.product
+++ b/releng/org.palladiosimulator.experimentautomation.product/product.product
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?pde version="3.5"?>
+<product name="Palladio Experiment Automation" uid="ExperimentAutomation"
+         id="org.palladiosimulator.experimentautomation.product"
+         application="org.palladiosimulator.experimentautomation.application"
+         version="6.0.0.qualifier" useFeatures="true" includeLaunchers="true">
+
+   <configIni use="default">
+   </configIni>
+
+   <launcherArgs>
+      <vmArgsMac>-XstartOnFirstThread -Dorg.eclipse.swt.internal.carbon.smallFonts</vmArgsMac>
+   </launcherArgs>
+
+   <windowImages/>
+
+   <features>
+      <feature id="org.palladiosimulator.pcm.feature"/>
+      <feature id="org.palladiosimulator.thirdpartywrapper.feature"/>
+      <feature id="ca.umontreal.iro.ssj.feature"/>
+      <feature id="de.uka.ipd.sdq.simulation.abstractsimengine.feature"/>
+      <feature id="org.palladiosimulator.simulation.abstractsimengine.ssj.feature"/>
+      <feature id="org.palladiosimulator.experimentautomation.application.feature"/>
+      <feature id="org.palladiosimulator.experimentautomation.application.tooladapter.simulizar.feature"/>
+      <feature id="org.palladiosimulator.experimentautomation.application.tooladapter.simucom.feature"/>
+   </features>
+
+   <configurations>
+      <plugin id="org.apache.felix.scr" autoStart="true" startLevel="2"/>
+      <plugin id="org.eclipse.core.runtime" autoStart="true" startLevel="0"/>
+      <plugin id="org.eclipse.equinox.common" autoStart="true" startLevel="2"/>
+      <plugin id="org.eclipse.equinox.event" autoStart="true" startLevel="2"/>
+      <plugin id="org.eclipse.equinox.simpleconfigurator" autoStart="true" startLevel="1"/>
+      <property name="osgi.instance.area.default" value="@user.home/workspace"/>
+   </configurations>
+
+</product>

--- a/releng/org.palladiosimulator.experimentautomation.product/product.product
+++ b/releng/org.palladiosimulator.experimentautomation.product/product.product
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <?pde version="3.5"?>
 <product name="Palladio Experiment Automation" uid="ExperimentAutomation"
-         id="org.palladiosimulator.experimentautomation.product"
+         id="org.palladiosimulator.experimentautomation.application.product"
          application="org.palladiosimulator.experimentautomation.application"
          version="6.0.0.qualifier" useFeatures="true" includeLaunchers="true">
 

--- a/releng/org.palladiosimulator.experimentautomation.updatesite/.project
+++ b/releng/org.palladiosimulator.experimentautomation.updatesite/.project
@@ -5,7 +5,24 @@
 	<projects>
 	</projects>
 	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121380</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/releng/org.palladiosimulator.experimentautomation.updatesite/.settings/org.eclipse.core.resources.prefs
+++ b/releng/org.palladiosimulator.experimentautomation.updatesite/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/releng/org.palladiosimulator.experimentautomation.updatesite/.settings/org.eclipse.m2e.core.prefs
+++ b/releng/org.palladiosimulator.experimentautomation.updatesite/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/tests/.project
+++ b/tests/.project
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<projectDescription>
+	<name>tests</name>
+	<comment></comment>
+	<projects>
+	</projects>
+	<buildSpec>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
+	</buildSpec>
+	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
+	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121382</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
+</projectDescription>

--- a/tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/.settings/org.eclipse.m2e.core.prefs
+++ b/tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1

--- a/tests/org.palladiosimulator.experimentautomation.application.tests/.project
+++ b/tests/org.palladiosimulator.experimentautomation.application.tests/.project
@@ -25,10 +25,27 @@
 			<arguments>
 			</arguments>
 		</buildCommand>
+		<buildCommand>
+			<name>org.eclipse.m2e.core.maven2Builder</name>
+			<arguments>
+			</arguments>
+		</buildCommand>
 	</buildSpec>
 	<natures>
+		<nature>org.eclipse.m2e.core.maven2Nature</nature>
 		<nature>org.eclipse.pde.PluginNature</nature>
 		<nature>org.eclipse.jdt.core.javanature</nature>
 		<nature>net.sf.eclipsecs.core.CheckstyleNature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1782312121366</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|\.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/tests/org.palladiosimulator.experimentautomation.application.tests/.settings/org.eclipse.core.resources.prefs
+++ b/tests/org.palladiosimulator.experimentautomation.application.tests/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/tests/org.palladiosimulator.experimentautomation.application.tests/.settings/org.eclipse.m2e.core.prefs
+++ b/tests/org.palladiosimulator.experimentautomation.application.tests/.settings/org.eclipse.m2e.core.prefs
@@ -1,0 +1,4 @@
+activeProfiles=
+eclipse.preferences.version=1
+resolveWorkspaceProjects=true
+version=1


### PR DESCRIPTION
Closes #37

## Summary

New `releng/org.palladiosimulator.experimentautomation.product/` module that builds a standalone Eclipse RCP product of the Experiment Automation.

## What it includes

- PCM core feature (models, resources → `pathmap://PCM_MODELS/` registration)
- Third-party wrapper (DESMO-J, Apache Commons Math, etc.)
- SSJ simulation library + SSJ engine adapter
- Abstract simulation engine API
- Experiment Automation application + tool adapters (SimuLizar, SimuCom)

## Build

```bash
# 1. Build the main project (updatesite)
mvn clean package -DskipTests

# 2. Build the product
mvn clean verify -f releng/org.palladiosimulator.experimentautomation.product/pom.xml
```

Output: 5 platform archives (~175 MB each) in `target/products/`.

## Verified

- Full build on macOS aarch64
- Headless experiment run with `SimpleVariation.experiments` → exit code 0
- SSJ engine resolved and bundled (no more NPE in engine initialisation)